### PR TITLE
Memory prover change multiplicies to u32 vec

### DIFF
--- a/stwo_cairo_prover/crates/prover/src/components/memory/mod.rs
+++ b/stwo_cairo_prover/crates/prover/src/components/memory/mod.rs
@@ -47,21 +47,7 @@ mod tests {
             addr_to_id_gen.add_inputs(*addr);
         });
 
-        assert_eq!(
-            addr_to_id_gen
-                .multiplicities
-                .iter()
-                .flat_map(|m| m.as_array())
-                .collect_vec(),
-            expected_addr_mult
-        );
-        assert_eq!(
-            id_to_f252
-                .multiplicities
-                .iter()
-                .flat_map(|m| m.as_array())
-                .collect_vec(),
-            expected_f252_mult
-        );
+        assert_eq!(addr_to_id_gen.multiplicities, expected_addr_mult);
+        assert_eq!(id_to_f252.multiplicities, expected_f252_mult);
     }
 }

--- a/stwo_cairo_prover/crates/prover/src/components/range_check_builtin/prover.rs
+++ b/stwo_cairo_prover/crates/prover/src/components/range_check_builtin/prover.rs
@@ -184,7 +184,6 @@ mod tests {
     use crate::components::memory::id_to_f252::{IdToF252LookupElements, N_BITS_PER_FELT};
     use crate::components::range_check_builtin::component::RangeCheckBuiltinEval;
     use crate::felt::split_f252;
-    use crate::prover_types::PackedUInt32;
 
     #[test]
     fn test_generate_trace() {
@@ -213,7 +212,7 @@ mod tests {
             .collect_vec();
         let memory_trace_generator = IdToF252ClaimProver {
             values: values.clone(),
-            multiplicities: vec![PackedUInt32::broadcast(0); 1 << (log_size - LOG_N_LANES)],
+            multiplicities: vec![0; 1 << log_size],
         };
         let (trace, interaction_prover) = write_trace_simd(&inputs, &memory_trace_generator);
 
@@ -303,7 +302,7 @@ mod tests {
             .collect_vec();
         let memory_trace_generator = IdToF252ClaimProver {
             values: values.clone(),
-            multiplicities: vec![PackedUInt32::broadcast(0); 1 << (mem_log_size - LOG_N_LANES)],
+            multiplicities: vec![0; 1 << mem_log_size],
         };
         let (trace, interaction_prover) = write_trace_simd(&inputs, &memory_trace_generator);
 


### PR DESCRIPTION

Change multiplicies vector to regular u32 instead of SIMD

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/143)
<!-- Reviewable:end -->
