### PR TITLE
Range check memory values in id_to_f252 trace generator

### DIFF
--- a/stwo_cairo_prover/crates/prover/src/cairo_air/mod.rs
+++ b/stwo_cairo_prover/crates/prover/src/cairo_air/mod.rs
@@ -267,12 +267,6 @@ pub fn prove_cairo(input: CairoInput) -> Result<CairoProof<Blake2sMerkleHasher>,
     let mut memory_id_to_value_trace_generator = id_to_f252::ClaimGenerator::new(&input.mem);
     let mut range_check_9_9_trace_generator = range_check_9_9::ClaimGenerator::new();
 
-    // Assuming the values are pushed in the correct order.
-    // TODO(Ohad): handle the inputs better and remove the assumption.
-    for (&l, &r) in input.range_check9.values.iter().tuples() {
-        range_check_9_9_trace_generator.add_m31([M31(l), M31(r)]);
-    }
-
     // Add public memory.
     // TODO(ShaharS): fix the use of public memory to support memory ids.
     for addr in &input.public_mem_addresses {
@@ -289,7 +283,8 @@ pub fn prove_cairo(input: CairoInput) -> Result<CairoProof<Blake2sMerkleHasher>,
     let (memory_addr_to_id_claim, memory_addr_to_id_interaction_prover) =
         memory_addr_to_id_trace_generator.write_trace(&mut tree_builder);
     let (memory_id_to_value_claim, memory_id_to_value_interaction_prover) =
-        memory_id_to_value_trace_generator.write_trace(&mut tree_builder);
+        memory_id_to_value_trace_generator
+            .write_trace(&mut tree_builder, &mut range_check_9_9_trace_generator);
     let (range_check9_9_claim, range_check9_9_interaction_prover) =
         range_check_9_9_trace_generator.write_trace(&mut tree_builder);
 

--- a/stwo_cairo_prover/crates/prover/src/components/memory/id_to_f252/component.rs
+++ b/stwo_cairo_prover/crates/prover/src/components/memory/id_to_f252/component.rs
@@ -13,10 +13,11 @@ use crate::components::range_check_vector::range_check_9_9;
 
 pub const MEMORY_ID_SIZE: usize = 1;
 pub const N_M31_IN_FELT252: usize = 28;
-pub const MULTIPLICITY_COLUMN_OFFSET: usize = N_M31_IN_FELT252 + MEMORY_ID_SIZE;
+pub const N_ID_AND_VALUE_COLUMNS: usize = MEMORY_ID_SIZE + N_M31_IN_FELT252;
+pub const MULTIPLICITY_COLUMN_OFFSET: usize = N_ID_AND_VALUE_COLUMNS;
 pub const N_MULTIPLICITY_COLUMNS: usize = 1;
 // TODO(AlonH): Make memory size configurable.
-pub const N_ID_TO_VALUE_COLUMNS: usize = MEMORY_ID_SIZE + N_M31_IN_FELT252 + N_MULTIPLICITY_COLUMNS;
+pub const N_COLUMNS: usize = N_ID_AND_VALUE_COLUMNS + N_MULTIPLICITY_COLUMNS;
 
 pub type Component = FrameworkComponent<Eval>;
 
@@ -34,7 +35,7 @@ pub struct Eval {
 }
 impl Eval {
     pub const fn n_columns(&self) -> usize {
-        N_ID_TO_VALUE_COLUMNS
+        N_COLUMNS
     }
     pub fn new(
         claim: Claim,
@@ -95,7 +96,7 @@ pub struct Claim {
 }
 impl Claim {
     pub fn log_sizes(&self) -> TreeVec<Vec<u32>> {
-        let interaction_0_log_size = vec![self.log_size; N_ID_TO_VALUE_COLUMNS];
+        let interaction_0_log_size = vec![self.log_size; N_COLUMNS];
         let interaction_1_log_size =
             vec![self.log_size; SECURE_EXTENSION_DEGREE * (N_M31_IN_FELT252 / 2 + 1)];
         let fixed_column_log_sizes = vec![self.log_size];

--- a/stwo_cairo_prover/crates/prover/src/components/memory/mod.rs
+++ b/stwo_cairo_prover/crates/prover/src/components/memory/mod.rs
@@ -11,15 +11,12 @@ mod tests {
 
     use crate::components::memory::addr_to_id;
     use crate::input::mem::{MemConfig, MemoryBuilder, MemoryValueId};
-    use crate::input::range_check_unit::RangeCheckUnitInput;
     use crate::input::vm_import::MemEntry;
 
     #[test]
     fn test_memory_trace_prover() {
-        let mut range_check9 = RangeCheckUnitInput::new();
         let memory = MemoryBuilder::from_iter(
             MemConfig::default(),
-            &mut range_check9,
             (0..10).map(|i| MemEntry {
                 addr: i,
                 val: [i as u32; 8],

--- a/stwo_cairo_prover/crates/prover/src/input/instructions.rs
+++ b/stwo_cairo_prover/crates/prover/src/input/instructions.rs
@@ -70,10 +70,7 @@ pub struct Instructions {
     pub generic: Vec<VmState>,
 }
 impl Instructions {
-    pub fn from_iter(
-        mut iter: impl Iterator<Item = TraceEntry>,
-        mem: &mut MemoryBuilder<'_>,
-    ) -> Self {
+    pub fn from_iter(mut iter: impl Iterator<Item = TraceEntry>, mem: &mut MemoryBuilder) -> Self {
         let mut res = Self::default();
 
         let Some(first) = iter.next() else {
@@ -89,7 +86,7 @@ impl Instructions {
         res
     }
 
-    fn push_instr(&mut self, mem: &mut MemoryBuilder<'_>, state: VmState) {
+    fn push_instr(&mut self, mem: &mut MemoryBuilder, state: VmState) {
         let VmState { ap, fp, pc } = state;
         let instruction = mem.get_inst(pc);
         let instruction = Instruction::decode(instruction);

--- a/stwo_cairo_prover/crates/prover/src/input/mod.rs
+++ b/stwo_cairo_prover/crates/prover/src/input/mod.rs
@@ -2,8 +2,6 @@ use instructions::Instructions;
 use mem::Memory;
 use serde::{Deserialize, Serialize};
 
-use self::range_check_unit::RangeCheckUnitInput;
-
 mod decode;
 pub mod instructions;
 pub mod mem;
@@ -19,7 +17,6 @@ pub struct CairoInput {
     pub instructions: Instructions,
     pub mem: Memory,
     pub public_mem_addresses: Vec<u32>,
-    pub range_check9: RangeCheckUnitInput,
 
     // Builtins.
     pub range_check_builtin: SegmentAddrs,

--- a/stwo_cairo_prover/crates/prover/src/input/plain.rs
+++ b/stwo_cairo_prover/crates/prover/src/input/plain.rs
@@ -8,7 +8,6 @@ use itertools::Itertools;
 
 use super::instructions::Instructions;
 use super::mem::{MemConfig, MemoryBuilder};
-use super::range_check_unit::RangeCheckUnitInput;
 use super::vm_import::MemEntry;
 use super::{CairoInput, SegmentAddrs};
 
@@ -63,9 +62,8 @@ pub fn input_from_finished_runner(runner: CairoRunner) -> CairoInput {
     let trace = runner.relocated_trace.unwrap();
     let trace = trace.iter().map(|t| t.clone().into());
 
-    let mut range_check9 = RangeCheckUnitInput::new();
     let mem_config = MemConfig::default();
-    let mut mem = MemoryBuilder::from_iter(mem_config, &mut range_check9, mem);
+    let mut mem = MemoryBuilder::from_iter(mem_config, mem);
     let instructions = Instructions::from_iter(trace, &mut mem);
 
     // TODO(spapini): Add output builtin to public memory.
@@ -74,7 +72,6 @@ pub fn input_from_finished_runner(runner: CairoRunner) -> CairoInput {
         instructions,
         mem: mem.build(),
         public_mem_addresses,
-        range_check9,
         range_check_builtin: SegmentAddrs {
             begin_addr: 24,
             end_addr: 64,

--- a/stwo_cairo_prover/crates/prover/src/input/vm_import/mod.rs
+++ b/stwo_cairo_prover/crates/prover/src/input/vm_import/mod.rs
@@ -13,7 +13,6 @@ use super::instructions::Instructions;
 use super::mem::MemConfig;
 use super::CairoInput;
 use crate::input::mem::MemoryBuilder;
-use crate::input::range_check_unit::RangeCheckUnitInput;
 use crate::input::SegmentAddrs;
 
 #[derive(Debug, Error)]
@@ -46,11 +45,9 @@ pub fn import_from_vm_output(
     let mem_path = priv_json.parent().unwrap().join(&priv_data.memory_path);
     let trace_path = priv_json.parent().unwrap().join(&priv_data.trace_path);
 
-    let mut range_check9 = RangeCheckUnitInput::new();
     let mut trace_file = std::io::BufReader::new(std::fs::File::open(trace_path)?);
     let mut mem_file = std::io::BufReader::new(std::fs::File::open(mem_path)?);
-    let mut mem =
-        MemoryBuilder::from_iter(mem_config, &mut range_check9, MemEntryIter(&mut mem_file));
+    let mut mem = MemoryBuilder::from_iter(mem_config, MemEntryIter(&mut mem_file));
     let instructions = Instructions::from_iter(TraceIter(&mut trace_file), &mut mem);
 
     let public_mem_addresses = pub_data
@@ -63,7 +60,6 @@ pub fn import_from_vm_output(
         instructions,
         mem: mem.build(),
         public_mem_addresses,
-        range_check9,
         range_check_builtin: SegmentAddrs {
             begin_addr: pub_data.memory_segments["range_check"].begin_addr as u32,
             end_addr: pub_data.memory_segments["range_check"].stop_ptr as u32,


### PR DESCRIPTION

Range check memory values from memory trace generator
Remove range check from MemoryBuilder

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/148)
<!-- Reviewable:end -->
