### PR TITLE
add adapter tests

### DIFF
--- a/stwo_cairo_prover/crates/adapted_prover/src/main.rs
+++ b/stwo_cairo_prover/crates/adapted_prover/src/main.rs
@@ -66,7 +66,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<CairoProof<Blake2sMerkleHas
     let args = Args::try_parse_from(args)?;
 
     let vm_output: CairoInput =
-        import_from_vm_output(args.pub_json.as_path(), args.priv_json.as_path())?;
+        import_from_vm_output(args.pub_json.as_path(), args.priv_json.as_path(), true)?;
 
     let casm_states_by_opcode_count = &vm_output.state_transitions.casm_states_by_opcode.counts();
     log::info!("Casm states by opcode count: {casm_states_by_opcode_count:?}");


### PR DESCRIPTION
Add a unit test to ensure instructions are correctly mapped with the adapter.
The only components that can’t be tested using casm! are:

jmp rel [ap/fp + offset]
jump abs [[ap/fp + offset1] + offset2]
[ap/fp + offset0] = [[ap/fp + offset1] + offset

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/245)
<!-- Reviewable:end -->
