### PR TITLE
add builtins to the adapter

### DIFF
--- a/stwo_cairo_prover/crates/adapted_prover/src/main.rs
+++ b/stwo_cairo_prover/crates/adapted_prover/src/main.rs
@@ -4,7 +4,7 @@ use std::process::ExitCode;
 use clap::Parser;
 use stwo_cairo_prover::cairo_air::air::CairoProof;
 use stwo_cairo_prover::cairo_air::prove_cairo;
-use stwo_cairo_prover::input::vm_import::{import_from_vm_output, VmImportError};
+use stwo_cairo_prover::input::vm_import::{adapt_vm_output, VmImportError};
 use stwo_cairo_prover::input::CairoInput;
 use stwo_cairo_utils::logging_utils::init_logging;
 use stwo_prover::core::prover::ProvingError;
@@ -65,8 +65,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<CairoProof<Blake2sMerkleHas
     let _span = span!(Level::INFO, "run").entered();
     let args = Args::try_parse_from(args)?;
 
-    let vm_output: CairoInput =
-        import_from_vm_output(args.pub_json.as_path(), args.priv_json.as_path())?;
+    let vm_output: CairoInput = adapt_vm_output(args.pub_json.as_path(), args.priv_json.as_path())?;
 
     let casm_states_by_opcode_count = &vm_output.state_transitions.casm_states_by_opcode.counts();
     log::info!("Casm states by opcode count: {casm_states_by_opcode_count:?}");

--- a/stwo_cairo_prover/crates/prover/src/input/builtins_segments.rs
+++ b/stwo_cairo_prover/crates/prover/src/input/builtins_segments.rs
@@ -1,0 +1,145 @@
+use std::collections::BTreeMap;
+
+use cairo_vm::air_public_input::MemorySegmentAddresses;
+
+// TODO(STAV): Understand if the adapter should pass builtins that won't be supported by stwo.
+/// This struct holds the builtins used in a Cairo program.
+/// Most of them are not implemented yet by Stwo.
+#[derive(Debug)]
+pub struct BuiltinsSegments {
+    pub range_check_bits_128_builtin: MemorySegmentAddresses,
+    pub range_check_bits_96_builtin: MemorySegmentAddresses,
+    pub bitwise_builtin: MemorySegmentAddresses,
+    pub add_mod_builtin: MemorySegmentAddresses,
+    pub ec_op_builtin: MemorySegmentAddresses,
+    pub ecdsa_builtin: MemorySegmentAddresses,
+    pub keccak_builtin: MemorySegmentAddresses,
+    pub mul_mod_builtin: MemorySegmentAddresses,
+    pub pedersen_builtin: MemorySegmentAddresses,
+    pub poseidon_builtin: MemorySegmentAddresses,
+}
+
+impl Default for BuiltinsSegments {
+    fn default() -> Self {
+        Self {
+            range_check_bits_128_builtin: MemorySegmentAddresses {
+                begin_addr: 0,
+                stop_ptr: 0,
+            },
+            range_check_bits_96_builtin: MemorySegmentAddresses {
+                begin_addr: 0,
+                stop_ptr: 0,
+            },
+            bitwise_builtin: MemorySegmentAddresses {
+                begin_addr: 0,
+                stop_ptr: 0,
+            },
+            add_mod_builtin: MemorySegmentAddresses {
+                begin_addr: 0,
+                stop_ptr: 0,
+            },
+            ec_op_builtin: MemorySegmentAddresses {
+                begin_addr: 0,
+                stop_ptr: 0,
+            },
+            ecdsa_builtin: MemorySegmentAddresses {
+                begin_addr: 0,
+                stop_ptr: 0,
+            },
+            keccak_builtin: MemorySegmentAddresses {
+                begin_addr: 0,
+                stop_ptr: 0,
+            },
+            mul_mod_builtin: MemorySegmentAddresses {
+                begin_addr: 0,
+                stop_ptr: 0,
+            },
+            pedersen_builtin: MemorySegmentAddresses {
+                begin_addr: 0,
+                stop_ptr: 0,
+            },
+            poseidon_builtin: MemorySegmentAddresses {
+                begin_addr: 0,
+                stop_ptr: 0,
+            },
+        }
+    }
+}
+impl BuiltinsSegments {
+    /// Create a new `BuiltinsSegments` struct from a map of memory MemorySegmentAddressess.
+    pub fn from_memory_segments(
+        memory_segments: &BTreeMap<String, MemorySegmentAddresses>,
+    ) -> Self {
+        let mut res = Self::default();
+        for (name, value) in memory_segments.iter() {
+            match name.as_str() {
+                "range_check" => {
+                    res.range_check_bits_128_builtin = MemorySegmentAddresses {
+                        begin_addr: value.begin_addr,
+                        stop_ptr: value.stop_ptr,
+                    }
+                }
+                "range_check96" => {
+                    res.range_check_bits_96_builtin = MemorySegmentAddresses {
+                        begin_addr: value.begin_addr,
+                        stop_ptr: value.stop_ptr,
+                    }
+                }
+                "bitwise" => {
+                    res.bitwise_builtin = MemorySegmentAddresses {
+                        begin_addr: value.begin_addr,
+                        stop_ptr: value.stop_ptr,
+                    }
+                }
+                "add_mod" => {
+                    res.add_mod_builtin = MemorySegmentAddresses {
+                        begin_addr: value.begin_addr,
+                        stop_ptr: value.stop_ptr,
+                    }
+                }
+                "ec_op" => {
+                    res.ec_op_builtin = MemorySegmentAddresses {
+                        begin_addr: value.begin_addr,
+                        stop_ptr: value.stop_ptr,
+                    }
+                }
+                "ecdsa" => {
+                    res.ecdsa_builtin = MemorySegmentAddresses {
+                        begin_addr: value.begin_addr,
+                        stop_ptr: value.stop_ptr,
+                    }
+                }
+                "keccak" => {
+                    res.keccak_builtin = MemorySegmentAddresses {
+                        begin_addr: value.begin_addr,
+                        stop_ptr: value.stop_ptr,
+                    }
+                }
+                "mul_mod" => {
+                    res.mul_mod_builtin = MemorySegmentAddresses {
+                        begin_addr: value.begin_addr,
+                        stop_ptr: value.stop_ptr,
+                    }
+                }
+                "pedersen" => {
+                    res.pedersen_builtin = MemorySegmentAddresses {
+                        begin_addr: value.begin_addr,
+                        stop_ptr: value.stop_ptr,
+                    }
+                }
+                "poseidon" => {
+                    res.poseidon_builtin = MemorySegmentAddresses {
+                        begin_addr: value.begin_addr,
+                        stop_ptr: value.stop_ptr,
+                    }
+                }
+                // Output, executaion and program segments are not builtins.
+                "output" => {}
+                "execution" => {}
+                "program" => {}
+                _ => panic!("Unknown memory segment: {name}"),
+            }
+        }
+        res
+    }
+}

--- a/stwo_cairo_prover/crates/prover/src/input/mod.rs
+++ b/stwo_cairo_prover/crates/prover/src/input/mod.rs
@@ -1,7 +1,8 @@
+use builtins_segments::BuiltinsSegments;
 use mem::Memory;
-use serde::{Deserialize, Serialize};
 use state_transitions::StateTransitions;
 
+pub mod builtins_segments;
 mod decode;
 pub mod mem;
 pub mod plain;
@@ -19,17 +20,5 @@ pub struct CairoInput {
     pub public_mem_addresses: Vec<u32>,
 
     // Builtins.
-    pub range_check_builtin: SegmentAddrs,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SegmentAddrs {
-    pub begin_addr: u32,
-    pub end_addr: u32,
-}
-
-impl SegmentAddrs {
-    pub fn addresses(&self) -> Vec<u32> {
-        (self.begin_addr..self.end_addr).collect()
-    }
+    pub builtins_segments: BuiltinsSegments,
 }

--- a/stwo_cairo_prover/crates/prover/src/input/plain.rs
+++ b/stwo_cairo_prover/crates/prover/src/input/plain.rs
@@ -1,15 +1,15 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
+use cairo_vm::air_public_input::MemorySegmentAddresses;
 use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::BuiltinHintProcessor;
 use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::types::relocatable::MaybeRelocatable;
 use cairo_vm::vm::runners::cairo_runner::CairoRunner;
 use itertools::Itertools;
 
-use super::mem::{MemConfig, MemoryBuilder};
-use super::state_transitions::StateTransitions;
-use super::vm_import::MemEntry;
-use super::{CairoInput, SegmentAddrs};
+use super::vm_import::{adapter, MemEntry};
+use super::CairoInput;
+use crate::input::mem::{MemConfig, MemoryBuilder};
 
 // TODO(Ohad): remove dev_mode after adding the rest of the opcodes.
 /// Translates a plain casm into a CairoInput by running the program and extracting the memory and
@@ -50,17 +50,17 @@ pub fn input_from_plain_casm(
         )
         .expect("Run failed");
     runner.relocate(true).unwrap();
-    input_from_finished_runner(runner, dev_mode)
+    adapt_finished_runner(runner, dev_mode)
 }
 
 // TODO(yuval): consider returning a result instead of panicking.
 // TODO(Ohad): remove dev_mode after adding the rest of the opcodes.
-/// Assumes memory and trace are already relocated. Otherwise panics.
 /// When dev mod is enabled, the opcodes generated from the plain casm will be mapped to the generic
 /// component only.
-pub fn input_from_finished_runner(runner: CairoRunner, dev_mode: bool) -> CairoInput {
-    let program_len = runner.get_program().iter_data().count();
-    let mem = runner
+/// Translates a CairoRunner into a CairoInput by extracting the relevant input to the adapter.
+/// Assumes memory and trace are already relocated. Otherwise panics.
+pub fn adapt_finished_runner(runner: CairoRunner, dev_mode: bool) -> CairoInput {
+    let mem_iter = runner
         .relocated_memory
         .iter()
         .enumerate()
@@ -70,22 +70,34 @@ pub fn input_from_finished_runner(runner: CairoRunner, dev_mode: bool) -> CairoI
                 val: bytemuck::cast_slice(&v.to_bytes_le()).try_into().unwrap(),
             })
         });
-    let trace = runner.relocated_trace.unwrap();
-    let trace = trace.iter().map(|t| t.clone().into());
 
-    let mem_config = MemConfig::default();
-    let mut mem = MemoryBuilder::from_iter(mem_config, mem);
-    let state_transitions = StateTransitions::from_iter(trace, &mut mem, dev_mode);
+    let trace = runner.relocated_trace.clone().unwrap();
+    let trace_iter = trace.iter().map(|t| t.clone().into());
 
-    // TODO(spapini): Add output builtin to public memory.
-    let public_mem_addresses = (0..(program_len as u32)).collect_vec();
-    CairoInput {
-        state_transitions,
-        mem: mem.build(),
+    let public_input = runner
+        .get_air_public_input()
+        .expect("Unable to get public input from the runner");
+    let public_mem_addresses = public_input
+        .public_memory
+        .into_iter()
+        .map(|s| s.address as u32)
+        .collect::<Vec<u32>>();
+
+    let memory_segments = public_input
+        .memory_segments
+        .into_iter()
+        .map(|(s, m)| (s.to_string(), m))
+        .collect::<BTreeMap<String, MemorySegmentAddresses>>();
+
+    let cairo_input = adapter(
+        trace_iter,
+        MemoryBuilder::from_iter(MemConfig::default(), mem_iter),
         public_mem_addresses,
-        range_check_builtin: SegmentAddrs {
-            begin_addr: 24,
-            end_addr: 64,
-        },
+        &memory_segments,
+        dev_mode,
+    );
+    match cairo_input {
+        Ok(cairo_input) => cairo_input,
+        Err(e) => panic!("Error: {e}"),
     }
 }

--- a/stwo_cairo_prover/crates/prover/src/input/vm_import/json.rs
+++ b/stwo_cairo_prover/crates/prover/src/input/vm_import/json.rs
@@ -1,29 +1,17 @@
 use std::collections::BTreeMap;
 
+use cairo_vm::air_public_input::{MemorySegmentAddresses, PublicMemoryEntry};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct PublicInput {
     pub layout: String,
     pub rc_min: u64,
     pub rc_max: u64,
     pub n_steps: u64,
-    pub memory_segments: BTreeMap<String, Segment>,
-    pub public_memory: Vec<PublicMemEntry>,
+    pub memory_segments: BTreeMap<String, MemorySegmentAddresses>,
+    pub public_memory: Vec<PublicMemoryEntry>,
     pub dynamic_params: Option<()>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Segment {
-    pub begin_addr: u64,
-    pub stop_ptr: u64,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PublicMemEntry {
-    pub address: u64,
-    pub value: FeltValue,
-    pub page: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/stwo_cairo_prover/crates/vm_runner/src/main.rs
+++ b/stwo_cairo_prover/crates/vm_runner/src/main.rs
@@ -8,7 +8,7 @@ use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
 use cairo_vm::vm::runners::cairo_pie::CairoPie;
 use cairo_vm::vm::runners::cairo_runner::{CairoRunner, RunResources};
 use clap::{Parser, ValueHint};
-use stwo_cairo_prover::input::plain::input_from_finished_runner;
+use stwo_cairo_prover::input::plain::adapt_finished_runner;
 use stwo_cairo_prover::input::CairoInput;
 use stwo_cairo_utils::logging_utils::init_logging;
 use thiserror::Error;
@@ -150,5 +150,5 @@ fn run_vm(args: &Args) -> Result<CairoRunner, Error> {
 /// Assumes memory and trace are already relocated. Otherwise panics.
 fn adapt_vm_output_to_stwo(runner: CairoRunner) -> CairoInput {
     let _span = tracing::info_span!("adapt_vm_output_to_stwo").entered();
-    input_from_finished_runner(runner, false)
+    adapt_finished_runner(runner, false)
 }


### PR DESCRIPTION
On the way:
1. Rename functions to include "adapt" in their names.
2. Unify the adapter functionality used by both the validator and the prover.
3. Remove the SegmentAddr struct, which is similar to the Segment defined in json.rs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/263)
<!-- Reviewable:end -->
