### PR TITLE
Added Felt252Packed27 prover type

### DIFF
--- a/stwo_cairo_prover/crates/prover_types/src/cpu.rs
+++ b/stwo_cairo_prover/crates/prover_types/src/cpu.rs
@@ -563,6 +563,84 @@ impl ProverType for Felt252 {
     }
 }
 
+pub const FELT252PACKED27_N_WORDS: usize = 10;
+pub const FELT252PACKED27_BITS_PER_WORD: usize = 27;
+
+pub const P_PACKED27_FELTS: [u32; FELT252PACKED27_N_WORDS] = [1, 0, 0, 0, 0, 0, 0, 136, 0, 256];
+/// A version of Felt252 whose values are packed into 27-bit limbs instead of 9-bit.
+/// The only supported operations are conversions to and from Felt252.
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, Default, Eq, PartialEq, Hash)]
+pub struct Felt252Packed27 {
+    pub limbs: [u64; 4],
+}
+
+impl Felt252Packed27 {
+    pub fn get_m31(&self, index: usize) -> M31 {
+        let mask = (1u64 << FELT252PACKED27_BITS_PER_WORD) - 1;
+        let shift = FELT252PACKED27_BITS_PER_WORD * index;
+        let low_limb = shift / 64;
+        let shift_low = shift & 0x3F;
+        let high_limb = (shift + FELT252PACKED27_BITS_PER_WORD - 1) / 64;
+        let value = if low_limb == high_limb || index == (FELT252PACKED27_N_WORDS - 1) {
+            ((self.limbs[low_limb] >> (shift_low)) & mask) as u32
+        } else {
+            (((self.limbs[low_limb] >> (shift_low)) | (self.limbs[high_limb] << (64 - shift_low)))
+                & mask) as u32
+        };
+        M31::from_u32_unchecked(value)
+    }
+
+    pub fn from_limbs(felts: &[M31]) -> Self {
+        assert!(
+            felts.len() <= FELT252PACKED27_N_WORDS,
+            "Invalid number of felts"
+        );
+        let mut limbs = [0u64; 4];
+        for (index, felt) in felts.iter().enumerate() {
+            let shift = FELT252PACKED27_BITS_PER_WORD * index;
+            let shift_low = shift & 0x3F;
+            let low_limb = shift / 64;
+            let high_limb = (shift + FELT252PACKED27_BITS_PER_WORD - 1) / 64;
+            limbs[low_limb] |= (felt.0 as u64) << shift_low;
+            if high_limb != low_limb && index < (FELT252PACKED27_N_WORDS - 1) {
+                limbs[high_limb] |= (felt.0 as u64) >> (64 - shift_low);
+            }
+        }
+
+        Self { limbs }
+    }
+
+    pub fn from_m31(felt: M31) -> Self {
+        Self {
+            limbs: [felt.0 as u64, 0, 0, 0],
+        }
+    }
+}
+
+impl From<Felt252> for Felt252Packed27 {
+    fn from(n: Felt252) -> Felt252Packed27 {
+        Felt252Packed27 { limbs: n.limbs }
+    }
+}
+
+impl From<Felt252Packed27> for Felt252 {
+    fn from(n: Felt252Packed27) -> Felt252 {
+        Felt252 { limbs: n.limbs }
+    }
+}
+
+impl ProverType for Felt252Packed27 {
+    fn calc(&self) -> String {
+        format!(
+            "[{}, {}, {}, {}]",
+            self.limbs[0], self.limbs[1], self.limbs[2], self.limbs[3]
+        )
+    }
+    fn r#type() -> String {
+        "Felt252Packed27".to_string()
+    }
+}
+
 // Length of each modulo builtin word in bits.
 pub const MOD_BUILTIN_WORD_BIT_LEN: usize = 96;
 // Length of each biguint word in bits.


### PR DESCRIPTION
An additional prover type for felt252 which uses trace cells more efficiently for operations such as lookups and additions (but less efficiently for multiplications), as are common in Poseidon.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/289)
<!-- Reviewable:end -->
