### PR TITLE
Add optional prover parameters file path to the adapted Stwo CLI

### DIFF
--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -1749,7 +1749,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "stwo-air-utils"
 version = "0.1.1"
-source = "git+https://github.com/starkware-libs/stwo?rev=438c107#438c1075b0c43a0cb271929888de2902d507ae32"
+source = "git+https://github.com/starkware-libs/stwo?rev=0445252#0445252fe30180c44f7e742c301b5ecd7273c91f"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -1761,7 +1761,7 @@ dependencies = [
 [[package]]
 name = "stwo-air-utils-derive"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=438c107#438c1075b0c43a0cb271929888de2902d507ae32"
+source = "git+https://github.com/starkware-libs/stwo?rev=0445252#0445252fe30180c44f7e742c301b5ecd7273c91f"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -1790,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "stwo-prover"
 version = "0.1.1"
-source = "git+https://github.com/starkware-libs/stwo?rev=438c107#438c1075b0c43a0cb271929888de2902d507ae32"
+source = "git+https://github.com/starkware-libs/stwo?rev=0445252#0445252fe30180c44f7e742c301b5ecd7273c91f"
 dependencies = [
  "blake2",
  "blake3",

--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "log",
+ "serde",
  "serde_json",
  "stwo-prover",
  "stwo_cairo_prover",
@@ -502,26 +503,6 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
-name = "const_format"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
 
 [[package]]
 name = "constant_time_eq"
@@ -1112,30 +1093,28 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.2"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91c2d9a6a6004e205b7e881856fb1a0f5022d382acc2c01b52185f7b6f65997"
+checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
 dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
- "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.2"
+version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77555fd9d578b6470470463fded832619a5fec5ad6cbc551fe4d7507ce50cd3a"
+checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1504,12 +1483,6 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.25",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -2120,12 +2093,6 @@ name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"

--- a/stwo_cairo_prover/Cargo.toml
+++ b/stwo_cairo_prover/Cargo.toml
@@ -36,9 +36,11 @@ serde_json = "1.0.1"
 stwo_cairo_prover = { path = "crates/prover", version = "~0.1.0" }
 stwo_cairo_utils = { path = "crates/utils", version = "~0.1.0" }
 # TODO(ShaharS): take stwo version from the source repository.
-stwo-prover = { git = "https://github.com/starkware-libs/stwo", rev = "438c107", features = [
+stwo-prover = { git = "https://github.com/starkware-libs/stwo", rev = "0445252", features = [
     "parallel",
 ], default-features = false }
+stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "0445252" }
+stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "0445252" }
 thiserror = { version = "2.0.10", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/stwo_cairo_prover/crates/adapted_prover/Cargo.toml
+++ b/stwo_cairo_prover/crates/adapted_prover/Cargo.toml
@@ -15,3 +15,4 @@ stwo_cairo_utils.workspace = true
 stwo-prover.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+serde.workspace = true

--- a/stwo_cairo_prover/crates/cairo-serialize/src/lib.rs
+++ b/stwo_cairo_prover/crates/cairo-serialize/src/lib.rs
@@ -4,7 +4,7 @@ pub use stwo_cairo_serialize_derive::CairoSerialize;
 use stwo_prover::core::fields::m31::BaseField;
 use stwo_prover::core::fields::qm31::SecureField;
 use stwo_prover::core::fri::{FriLayerProof, FriProof};
-use stwo_prover::core::pcs::CommitmentSchemeProof;
+use stwo_prover::core::pcs::{CommitmentSchemeProof, PcsConfig};
 use stwo_prover::core::poly::line::LinePoly;
 use stwo_prover::core::prover::StarkProof;
 use stwo_prover::core::vcs::ops::MerkleHasher;
@@ -116,6 +116,7 @@ where
             queried_values,
             proof_of_work,
             fri_proof,
+            config,
         } = self;
         commitments.serialize(output);
         sampled_values.serialize(output);
@@ -123,6 +124,7 @@ where
         queried_values.serialize(output);
         output.push((*proof_of_work).into());
         fri_proof.serialize(output);
+        config.serialize(output);
     }
 }
 
@@ -181,5 +183,14 @@ impl<T0: CairoSerialize, T1: CairoSerialize, T2: CairoSerialize> CairoSerialize 
         v0.serialize(output);
         v1.serialize(output);
         v2.serialize(output);
+    }
+}
+
+impl CairoSerialize for PcsConfig {
+    fn serialize(&self, output: &mut Vec<FieldElement>) {
+        output.push((self.pow_bits).into());
+        output.push((self.fri_config.log_blowup_factor).into());
+        output.push((self.fri_config.log_last_layer_degree_bound).into());
+        output.push((self.fri_config.n_queries).into());
     }
 }

--- a/stwo_cairo_prover/crates/prover/Cargo.toml
+++ b/stwo_cairo_prover/crates/prover/Cargo.toml
@@ -9,8 +9,8 @@ std = ["dep:sonic-rs"]
 
 [dependencies]
 air_structs_derive = { path = "../air_structs_derive" }
-stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "438c107" }
-stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "438c107" }
+stwo-air-utils-derive.workspace = true
+stwo-air-utils.workspace = true
 bytemuck.workspace = true
 cairo-lang-casm.workspace = true
 cairo-vm.workspace = true

--- a/stwo_cairo_prover/crates/prover/src/cairo_air/mod.rs
+++ b/stwo_cairo_prover/crates/prover/src/cairo_air/mod.rs
@@ -9,12 +9,12 @@ use air::{lookup_sum, CairoClaimGenerator, CairoComponents, CairoInteractionElem
 use debug_tools::track_cairo_relations;
 use num_traits::Zero;
 use preprocessed::preprocessed_trace_columns;
+use serde::{Deserialize, Serialize};
 use stwo_prover::constraint_framework::relation_tracker::RelationSummary;
 use stwo_prover::core::backend::simd::SimdBackend;
 use stwo_prover::core::backend::BackendForChannel;
 use stwo_prover::core::channel::MerkleChannel;
 use stwo_prover::core::fields::qm31::SecureField;
-use stwo_prover::core::fri::FriConfig;
 use stwo_prover::core::pcs::{CommitmentSchemeProver, CommitmentSchemeVerifier, PcsConfig};
 use stwo_prover::core::poly::circle::{CanonicCoset, PolyOps};
 use stwo_prover::core::prover::{prove, verify, ProvingError, VerificationError};
@@ -34,29 +34,23 @@ pub fn prove_cairo<MC: MerkleChannel>(
         track_relations,
         display_components,
     }: ProverConfig,
+    pcs_config: PcsConfig,
 ) -> Result<CairoProof<MC::H>, ProvingError>
 where
     SimdBackend: BackendForChannel<MC>,
 {
     let _span = span!(Level::INFO, "prove_cairo").entered();
-    // TODO(Ohad): Propogate config from CLI args.
-    let config = PcsConfig {
-        pow_bits: 0,
-        fri_config: FriConfig {
-            log_last_layer_degree_bound: 2,
-            log_blowup_factor: 1,
-            n_queries: 15,
-        },
-    };
+
     let twiddles = SimdBackend::precompute_twiddles(
-        CanonicCoset::new(LOG_MAX_ROWS + config.fri_config.log_blowup_factor + 2)
+        CanonicCoset::new(LOG_MAX_ROWS + pcs_config.fri_config.log_blowup_factor + 2)
             .circle_domain()
             .half_coset,
     );
 
     // Setup protocol.
     let channel = &mut MC::C::default();
-    let mut commitment_scheme = CommitmentSchemeProver::<SimdBackend, MC>::new(config, &twiddles);
+    let mut commitment_scheme =
+        CommitmentSchemeProver::<SimdBackend, MC>::new(pcs_config, &twiddles);
 
     // Preprocessed trace.
     let mut tree_builder = commitment_scheme.tree_builder();
@@ -127,7 +121,10 @@ pub fn verify_cairo<MC: MerkleChannel>(
         interaction_claim,
         stark_proof,
     }: CairoProof<MC::H>,
+    pcs_config: PcsConfig,
 ) -> Result<(), CairoVerificationError> {
+    let _span = span!(Level::INFO, "verify_cairo").entered();
+
     // Auxiliary verifications.
     // Assert that ADDRESS->ID component does not overflow.
     assert!(
@@ -136,17 +133,8 @@ pub fn verify_cairo<MC: MerkleChannel>(
     );
 
     // Setup STARK protocol.
-    // TODO(Ohad): Propagate config from CLI args.
-    let config = PcsConfig {
-        pow_bits: 0,
-        fri_config: FriConfig {
-            log_last_layer_degree_bound: 2,
-            log_blowup_factor: 1,
-            n_queries: 15,
-        },
-    };
     let channel = &mut MC::C::default();
-    let commitment_scheme_verifier = &mut CommitmentSchemeVerifier::<MC>::new(config);
+    let commitment_scheme_verifier = &mut CommitmentSchemeVerifier::<MC>::new(pcs_config);
 
     let log_sizes = claim.log_sizes();
 
@@ -219,6 +207,25 @@ impl ConfigBuilder {
     }
 }
 
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ProverParameters {
+    pub channel_hash: ChannelHash,
+    pub pcs_config: PcsConfig,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelHash {
+    Blake2s,
+    Poseidon252,
+}
+
+impl Default for ChannelHash {
+    fn default() -> Self {
+        Self::Blake2s
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum CairoVerificationError {
     #[error("Invalid logup sum")]
@@ -230,6 +237,7 @@ pub enum CairoVerificationError {
 #[cfg(test)]
 mod tests {
     use cairo_lang_casm::casm;
+    use stwo_prover::core::pcs::PcsConfig;
     use stwo_prover::core::vcs::blake2_merkle::Blake2sMerkleChannel;
 
     use super::ProverConfig;
@@ -271,8 +279,10 @@ mod tests {
 
     #[test]
     fn test_basic_cairo_air() {
-        let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(test_input(), test_cfg()).unwrap();
-        verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
+        let cairo_proof =
+            prove_cairo::<Blake2sMerkleChannel>(test_input(), test_cfg(), PcsConfig::default())
+                .unwrap();
+        verify_cairo::<Blake2sMerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
     }
 
     #[cfg(feature = "slow-tests")]
@@ -289,21 +299,29 @@ mod tests {
 
         #[test]
         fn generate_and_serialise_proof() {
-            let cairo_proof =
-                prove_cairo::<Poseidon252MerkleChannel>(test_input(), test_cfg()).unwrap();
+            let cairo_proof = prove_cairo::<Poseidon252MerkleChannel>(
+                test_input(),
+                test_cfg(),
+                PcsConfig::default(),
+            )
+            .unwrap();
             let mut output = Vec::new();
             CairoSerialize::serialize(&cairo_proof, &mut output);
             let proof_str = output.iter().map(|v| v.to_string()).join(",");
             let mut file = std::fs::File::create("proof.cairo").unwrap();
             file.write_all(proof_str.as_bytes()).unwrap();
-            verify_cairo::<Poseidon252MerkleChannel>(cairo_proof).unwrap();
+            verify_cairo::<Poseidon252MerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
         }
 
         #[test]
         fn test_full_cairo_air() {
-            let cairo_proof =
-                prove_cairo::<Blake2sMerkleChannel>(small_cairo_input(), test_cfg()).unwrap();
-            verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
+            let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(
+                small_cairo_input(),
+                test_cfg(),
+                PcsConfig::default(),
+            )
+            .unwrap();
+            verify_cairo::<Blake2sMerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
         }
     }
 }

--- a/stwo_cairo_prover/crates/recursion_bridge/src/proof_generation/mod.rs
+++ b/stwo_cairo_prover/crates/recursion_bridge/src/proof_generation/mod.rs
@@ -5,6 +5,7 @@ mod tests {
     use cairo_lang_casm::casm;
     use stwo_cairo_prover::cairo_air::{prove_cairo, verify_cairo, ProverConfig};
     use stwo_cairo_prover::input::plain::input_from_plain_casm_with_step_limit;
+    use stwo_prover::core::pcs::PcsConfig;
     use stwo_prover::core::vcs::blake2_merkle::Blake2sMerkleChannel;
 
     pub fn project_root() -> PathBuf {
@@ -21,11 +22,16 @@ mod tests {
         .instructions;
 
         let input = input_from_plain_casm_with_step_limit(instructions, 14);
-        let proof = prove_cairo::<Blake2sMerkleChannel>(input, ProverConfig::default()).unwrap();
+        let proof = prove_cairo::<Blake2sMerkleChannel>(
+            input,
+            ProverConfig::default(),
+            PcsConfig::default(),
+        )
+        .unwrap();
 
         let path = project_root().join("artifacts/jrl0_proof.json");
         std::fs::write(path, serde_json::to_string(&proof).unwrap()).unwrap();
 
-        verify_cairo::<Blake2sMerkleChannel>(proof).unwrap();
+        verify_cairo::<Blake2sMerkleChannel>(proof, PcsConfig::default()).unwrap();
     }
 }

--- a/stwo_cairo_prover/crates/run_and_prove/src/main.rs
+++ b/stwo_cairo_prover/crates/run_and_prove/src/main.rs
@@ -9,6 +9,7 @@ use stwo_cairo_prover::input::plain::adapt_finished_runner;
 use stwo_cairo_prover::input::vm_import::VmImportError;
 use stwo_cairo_utils::binary_utils::run_binary;
 use stwo_cairo_utils::vm_utils::{run_vm, VmArgs, VmError};
+use stwo_prover::core::pcs::PcsConfig;
 use stwo_prover::core::prover::ProvingError;
 use stwo_prover::core::vcs::blake2_merkle::Blake2sMerkleChannel;
 use thiserror::Error;
@@ -76,12 +77,13 @@ fn run(args: impl Iterator<Item = String>) -> Result<(), Error> {
     );
 
     // TODO(Ohad): Propagate hash from CLI args.
-    let proof = prove_cairo::<Blake2sMerkleChannel>(cairo_input, prover_config)?;
+    let proof =
+        prove_cairo::<Blake2sMerkleChannel>(cairo_input, prover_config, PcsConfig::default())?;
 
     std::fs::write(args.proof_path, serde_json::to_string(&proof)?)?;
 
     if args.verify {
-        verify_cairo::<Blake2sMerkleChannel>(proof)?;
+        verify_cairo::<Blake2sMerkleChannel>(proof, PcsConfig::default())?;
         log::info!("Proof verified successfully");
     }
 


### PR DESCRIPTION
Similarly to Stone which had prover config and parameters files, this PR introduces an optional cmd argument pointing to the params file.

The expected format is the following:

```json
{
    "channel_hash": "blake2s",
    "pcs_config": {
        "pow_bits": 24,
        "fri_config": {
            "log_last_layer_degree_bound": 0,
            "log_blowup_factor": 2,
            "n_queries": 36
        }
    }
}
```

If the file is not specified, the defaults are set to ensure 96 bits of security.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/410)
<!-- Reviewable:end -->
