### PR TITLE
Bump Stwo dependency to 0445252

### DIFF
--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -1776,7 +1776,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "stwo-air-utils"
 version = "0.1.1"
-source = "git+https://github.com/starkware-libs/stwo?rev=438c107#438c1075b0c43a0cb271929888de2902d507ae32"
+source = "git+https://github.com/starkware-libs/stwo?rev=0445252#0445252fe30180c44f7e742c301b5ecd7273c91f"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -1788,7 +1788,7 @@ dependencies = [
 [[package]]
 name = "stwo-air-utils-derive"
 version = "0.1.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=438c107#438c1075b0c43a0cb271929888de2902d507ae32"
+source = "git+https://github.com/starkware-libs/stwo?rev=0445252#0445252fe30180c44f7e742c301b5ecd7273c91f"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -1817,7 +1817,7 @@ dependencies = [
 [[package]]
 name = "stwo-prover"
 version = "0.1.1"
-source = "git+https://github.com/starkware-libs/stwo?rev=438c107#438c1075b0c43a0cb271929888de2902d507ae32"
+source = "git+https://github.com/starkware-libs/stwo?rev=0445252#0445252fe30180c44f7e742c301b5ecd7273c91f"
 dependencies = [
  "blake2",
  "blake3",

--- a/stwo_cairo_prover/Cargo.toml
+++ b/stwo_cairo_prover/Cargo.toml
@@ -36,9 +36,11 @@ serde_json = "1.0.1"
 stwo_cairo_prover = { path = "crates/prover", version = "~0.1.0" }
 stwo_cairo_utils = { path = "crates/utils", version = "~0.1.0" }
 # TODO(ShaharS): take stwo version from the source repository.
-stwo-prover = { git = "https://github.com/starkware-libs/stwo", rev = "438c107", features = [
+stwo-prover = { git = "https://github.com/starkware-libs/stwo", rev = "0445252", features = [
     "parallel",
 ], default-features = false }
+stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "0445252" }
+stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "0445252" }
 thiserror = { version = "2.0.10", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/stwo_cairo_prover/crates/cairo-serialize/src/lib.rs
+++ b/stwo_cairo_prover/crates/cairo-serialize/src/lib.rs
@@ -4,7 +4,7 @@ pub use stwo_cairo_serialize_derive::CairoSerialize;
 use stwo_prover::core::fields::m31::BaseField;
 use stwo_prover::core::fields::qm31::SecureField;
 use stwo_prover::core::fri::{FriLayerProof, FriProof};
-use stwo_prover::core::pcs::CommitmentSchemeProof;
+use stwo_prover::core::pcs::{CommitmentSchemeProof, PcsConfig};
 use stwo_prover::core::poly::line::LinePoly;
 use stwo_prover::core::prover::StarkProof;
 use stwo_prover::core::vcs::ops::MerkleHasher;
@@ -116,6 +116,7 @@ where
             queried_values,
             proof_of_work,
             fri_proof,
+            config,
         } = self;
         commitments.serialize(output);
         sampled_values.serialize(output);
@@ -123,6 +124,7 @@ where
         queried_values.serialize(output);
         output.push((*proof_of_work).into());
         fri_proof.serialize(output);
+        config.serialize(output);
     }
 }
 
@@ -181,5 +183,14 @@ impl<T0: CairoSerialize, T1: CairoSerialize, T2: CairoSerialize> CairoSerialize 
         v0.serialize(output);
         v1.serialize(output);
         v2.serialize(output);
+    }
+}
+
+impl CairoSerialize for PcsConfig {
+    fn serialize(&self, output: &mut Vec<FieldElement>) {
+        output.push((self.pow_bits).into());
+        output.push((self.fri_config.log_blowup_factor).into());
+        output.push((self.fri_config.log_last_layer_degree_bound).into());
+        output.push((self.fri_config.n_queries).into());
     }
 }

--- a/stwo_cairo_prover/crates/prover/Cargo.toml
+++ b/stwo_cairo_prover/crates/prover/Cargo.toml
@@ -9,8 +9,8 @@ std = ["dep:sonic-rs"]
 
 [dependencies]
 air_structs_derive = { path = "../air_structs_derive" }
-stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "438c107" }
-stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "438c107" }
+stwo-air-utils-derive.workspace = true
+stwo-air-utils.workspace = true
 bytemuck.workspace = true
 cairo-lang-casm.workspace = true
 cairo-vm.workspace = true


### PR DESCRIPTION
Why: to leverage serde traits derived for `PcsConfig`

What:
- `stwo-prover`, `stwo-air-utils`, `stwo-air-utils-derive` bumped to [0445252](https://github.com/starkware-libs/stwo/tree/0445252fe30180c44f7e742c301b5ecd7273c91f)
- `CairoSerialize` implemented for `PcsConfig` since it's now part of `CommitmentSchemeProof`

related to #410

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/419)
<!-- Reviewable:end -->
