### PR TITLE
Add prover parameters file and set defaults to 96 bits

### DIFF
--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -251,7 +251,7 @@ checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -359,7 +359,7 @@ checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -370,15 +370,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3929a38c1d586e35e19dbdf7798b146fba3627b308417a6d373fea8939535b6b"
+checksum = "445d607f43c161ae0a60f603924fbd1b6766e10a2f19b7c205b1fc3a1d274e93"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5d7609abc99c15de7d7f90b8441b27e2bd52e930a3014c95a9b620e5d3211a"
+checksum = "a2584a7ce6ccb6ee465da709983f42162384df5b8c093fb4c2e935db749c61bd"
 dependencies = [
  "hashbrown 0.14.5",
  "indexmap",
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
  "shlex",
 ]
@@ -451,9 +451,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -473,14 +473,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -657,7 +657,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fastrlp"
@@ -837,7 +837,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -985,9 +985,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
 dependencies = [
  "adler2",
 ]
@@ -1009,7 +1009,7 @@ checksum = "1bb5c1d8184f13f7d0ccbeeca0def2f9a181bce2624302793005f5ca8aa62e5e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "overload"
@@ -1104,9 +1104,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.7.2"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91c2d9a6a6004e205b7e881856fb1a0f5022d382acc2c01b52185f7b6f65997"
+checksum = "c9fde3d0718baf5bc92f577d652001da0f8d54cd03a7974e118d04fc888dc23d"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -1120,14 +1120,14 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.7.2"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77555fd9d578b6470470463fded832619a5fec5ad6cbc551fe4d7507ce50cd3a"
+checksum = "581c837bb6b9541ce7faa9377c20616e4fb7650f6b0f68bc93c827ee504fb7b3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1224,7 +1224,7 @@ checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1338,7 +1338,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1389,7 +1389,7 @@ checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1536,7 +1536,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1595,9 +1595,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "sonic-number"
@@ -1690,7 +1690,7 @@ checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
 dependencies = [
  "starknet-curve 0.4.2",
  "starknet-ff",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1771,7 +1771,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1824,7 +1824,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1924,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1965,7 +1965,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1976,7 +1976,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2032,9 +2032,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2060,7 +2060,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2148,9 +2148,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 
 [[package]]
 name = "valuable"
@@ -2191,7 +2191,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -2213,7 +2213,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2321,9 +2321,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.25"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
 ]
@@ -2355,7 +2355,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2375,7 +2375,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/stwo_cairo_prover/Cargo.toml
+++ b/stwo_cairo_prover/Cargo.toml
@@ -41,6 +41,8 @@ stwo-cairo-common = { path = "crates/common" }
 stwo-prover = { git = "https://github.com/starkware-libs/stwo", rev = "a194fad", features = [
     "parallel",
 ], default-features = false }
+stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "a194fad" }
+stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "a194fad" }
 thiserror = { version = "2.0.10", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"

--- a/stwo_cairo_prover/crates/adapted_prover/src/main.rs
+++ b/stwo_cairo_prover/crates/adapted_prover/src/main.rs
@@ -5,9 +5,11 @@ use clap::Parser;
 use stwo_cairo_adapter::vm_import::{adapt_vm_output, VmImportError};
 use stwo_cairo_adapter::ProverInput;
 use stwo_cairo_prover::cairo_air::{
-    prove_cairo, verify_cairo, CairoVerificationError, ConfigBuilder,
+    default_prod_prover_parameters, prove_cairo, verify_cairo, CairoVerificationError,
+    ConfigBuilder, ProverParameters,
 };
 use stwo_cairo_utils::binary_utils::run_binary;
+use stwo_cairo_utils::file_utils::{read_to_string, IoErrorWithPath};
 use stwo_prover::core::prover::ProvingError;
 use stwo_prover::core::vcs::blake2_merkle::Blake2sMerkleChannel;
 use thiserror::Error;
@@ -35,6 +37,22 @@ struct Args {
     pub_json: PathBuf,
     #[structopt(long = "priv_json")]
     priv_json: PathBuf,
+    /// The path to the JSON file containing the prover parameters (optional).
+    /// The expected file format is:
+    ///     {
+    ///         "pcs_config": {
+    ///             "pow_bits": 26,
+    ///             "fri_config": {
+    ///                 "log_last_layer_degree_bound": 0,
+    ///                 "log_blowup_factor": 1,
+    ///                 "n_queries": 70
+    ///             }
+    ///         }
+    ///     }
+    ///
+    /// Default parameters are chosen to ensure 96 bits of security.
+    #[structopt(long = "params_json")]
+    params_json: Option<PathBuf>,
     /// The output file path for the proof.
     #[structopt(long = "proof_path")]
     proof_path: PathBuf,
@@ -61,6 +79,8 @@ enum Error {
     Verification(#[from] CairoVerificationError),
     #[error("VM import failed: {0}")]
     VmImport(#[from] VmImportError),
+    #[error("File IO failed: {0}")]
+    File(#[from] IoErrorWithPath),
 }
 
 fn main() -> ExitCode {
@@ -83,13 +103,18 @@ fn run(args: impl Iterator<Item = String>) -> Result<(), Error> {
         vm_output.state_transitions.casm_states_by_opcode
     );
 
+    let ProverParameters { pcs_config } = match args.params_json {
+        Some(path) => serde_json::from_str(&read_to_string(&path)?)?,
+        None => default_prod_prover_parameters(),
+    };
+
     // TODO(Ohad): Propagate hash from CLI args.
-    let proof = prove_cairo::<Blake2sMerkleChannel>(vm_output, prover_config)?;
+    let proof = prove_cairo::<Blake2sMerkleChannel>(vm_output, prover_config, pcs_config)?;
 
     std::fs::write(args.proof_path, serde_json::to_string(&proof)?)?;
 
     if args.verify {
-        verify_cairo::<Blake2sMerkleChannel>(proof)?;
+        verify_cairo::<Blake2sMerkleChannel>(proof, pcs_config)?;
         log::info!("Proof verified successfully");
     }
 

--- a/stwo_cairo_prover/crates/prover/Cargo.toml
+++ b/stwo_cairo_prover/crates/prover/Cargo.toml
@@ -12,8 +12,8 @@ slow-tests = []
 nightly = []
 
 [dependencies]
-stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "a194fad" }
-stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "a194fad" }
+stwo-air-utils-derive.workspace = true
+stwo-air-utils.workspace = true
 bytemuck.workspace = true
 cairo-lang-casm.workspace = true
 cairo-vm.workspace = true

--- a/stwo_cairo_prover/crates/prover/src/cairo_air/mod.rs
+++ b/stwo_cairo_prover/crates/prover/src/cairo_air/mod.rs
@@ -14,6 +14,7 @@ use air::{lookup_sum, CairoClaimGenerator, CairoComponents, CairoInteractionElem
 use debug_tools::track_cairo_relations;
 use num_traits::Zero;
 use preprocessed::PreProcessedTrace;
+use serde::{Deserialize, Serialize};
 use stwo_cairo_adapter::ProverInput;
 use stwo_cairo_common::memory::LOG_MEMORY_ADDRESS_BOUND;
 use stwo_prover::constraint_framework::relation_tracker::RelationSummary;
@@ -38,30 +39,22 @@ pub fn prove_cairo<MC: MerkleChannel>(
         track_relations,
         display_components,
     }: ProverConfig,
+    pcs_config: PcsConfig,
 ) -> Result<CairoProof<MC::H>, ProvingError>
 where
     SimdBackend: BackendForChannel<MC>,
 {
     let _span = span!(Level::INFO, "prove_cairo").entered();
-    // TODO(Ohad): Propogate config from CLI args.
-    let config = PcsConfig {
-        // NOTE: low pow_bits might yield non-deterministic POWs.
-        pow_bits: 20,
-        fri_config: FriConfig {
-            log_last_layer_degree_bound: 2,
-            log_blowup_factor: 1,
-            n_queries: 15,
-        },
-    };
     let twiddles = SimdBackend::precompute_twiddles(
-        CanonicCoset::new(LOG_MAX_ROWS + config.fri_config.log_blowup_factor + 2)
+        CanonicCoset::new(LOG_MAX_ROWS + pcs_config.fri_config.log_blowup_factor + 2)
             .circle_domain()
             .half_coset,
     );
 
     // Setup protocol.
     let channel = &mut MC::C::default();
-    let mut commitment_scheme = CommitmentSchemeProver::<SimdBackend, MC>::new(config, &twiddles);
+    let mut commitment_scheme =
+        CommitmentSchemeProver::<SimdBackend, MC>::new(pcs_config, &twiddles);
 
     // Preprocessed trace.
     let mut tree_builder = commitment_scheme.tree_builder();
@@ -128,6 +121,7 @@ pub fn verify_cairo<MC: MerkleChannel>(
         interaction_claim,
         stark_proof,
     }: CairoProof<MC::H>,
+    pcs_config: PcsConfig,
 ) -> Result<(), CairoVerificationError> {
     // Auxiliary verifications.
     // Assert that ADDRESS->ID component does not overflow.
@@ -136,18 +130,8 @@ pub fn verify_cairo<MC: MerkleChannel>(
             <= (1 << LOG_MEMORY_ADDRESS_BOUND)
     );
 
-    // Setup STARK protocol.
-    // TODO(Ohad): Propagate config from CLI args.
-    let config = PcsConfig {
-        pow_bits: 0,
-        fri_config: FriConfig {
-            log_last_layer_degree_bound: 2,
-            log_blowup_factor: 1,
-            n_queries: 15,
-        },
-    };
     let channel = &mut MC::C::default();
-    let commitment_scheme_verifier = &mut CommitmentSchemeVerifier::<MC>::new(config);
+    let commitment_scheme_verifier = &mut CommitmentSchemeVerifier::<MC>::new(pcs_config);
 
     let log_sizes = claim.log_sizes();
 
@@ -220,6 +204,35 @@ impl ConfigBuilder {
     }
 }
 
+/// Concrete parameters of the proving system.
+/// Used both for producing and verifying proofs.
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ProverParameters {
+    /// Parameters of the commitment scheme.
+    pub pcs_config: PcsConfig,
+    // TODO(m-kus): add channel hash type here
+}
+
+/// The default prover parameters for prod use (96 bits of security).
+/// The formula is `security_bits = pow_bits + log_blowup_factor * n_queries`.
+pub fn default_prod_prover_parameters() -> ProverParameters {
+    ProverParameters {
+        pcs_config: PcsConfig {
+            // Stay within 500ms on M3.
+            pow_bits: 26,
+            fri_config: FriConfig {
+                log_last_layer_degree_bound: 0,
+                // Blowup factor > 1 significantly degrades proving speed.
+                // Can be in range [1, 16].
+                log_blowup_factor: 1,
+                // The more FRI queries, the larger the proof.
+                // Proving time is not affected much by increasing this value.
+                n_queries: 70,
+            },
+        },
+    }
+}
+
 #[derive(Error, Debug)]
 pub enum CairoVerificationError {
     #[error("Invalid logup sum")]
@@ -233,6 +246,7 @@ pub mod tests {
 
     use cairo_lang_casm::casm;
     use stwo_cairo_adapter::plain::input_from_plain_casm;
+    use stwo_prover::core::pcs::PcsConfig;
     use stwo_prover::core::vcs::blake2_merkle::Blake2sMerkleChannel;
 
     use super::ProverConfig;
@@ -273,9 +287,13 @@ pub mod tests {
 
     #[test]
     fn test_basic_cairo_air() {
-        let cairo_proof =
-            prove_cairo::<Blake2sMerkleChannel>(test_basic_cairo_air_input(), test_cfg()).unwrap();
-        verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
+        let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(
+            test_basic_cairo_air_input(),
+            test_cfg(),
+            PcsConfig::default(),
+        )
+        .unwrap();
+        verify_cairo::<Blake2sMerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
     }
 
     #[cfg(test)]
@@ -285,21 +303,25 @@ pub mod tests {
 
         use itertools::Itertools;
         use stwo_cairo_serialize::CairoSerialize;
+        use stwo_prover::core::pcs::PcsConfig;
         use stwo_prover::core::vcs::poseidon252_merkle::Poseidon252MerkleChannel;
 
         use super::*;
 
         #[test]
         fn generate_and_serialise_proof() {
-            let cairo_proof =
-                prove_cairo::<Poseidon252MerkleChannel>(test_basic_cairo_air_input(), test_cfg())
-                    .unwrap();
+            let cairo_proof = prove_cairo::<Poseidon252MerkleChannel>(
+                test_basic_cairo_air_input(),
+                test_cfg(),
+                PcsConfig::default(),
+            )
+            .unwrap();
             let mut output = Vec::new();
             CairoSerialize::serialize(&cairo_proof, &mut output);
             let proof_str = output.iter().map(|v| v.to_string()).join(",");
             let mut file = std::fs::File::create("proof.cairo").unwrap();
             file.write_all(proof_str.as_bytes()).unwrap();
-            verify_cairo::<Poseidon252MerkleChannel>(cairo_proof).unwrap();
+            verify_cairo::<Poseidon252MerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
         }
     }
 
@@ -317,9 +339,10 @@ pub mod tests {
             let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(
                 generate_test_input("test_read_from_small_files"),
                 test_cfg(),
+                PcsConfig::default(),
             )
             .unwrap();
-            verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
+            verify_cairo::<Blake2sMerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
         }
 
         #[test]
@@ -345,9 +368,10 @@ pub mod tests {
             let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(
                 generate_test_input("test_prove_verify_all_opcode_components"),
                 test_cfg(),
+                PcsConfig::default(),
             )
             .unwrap();
-            verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
+            verify_cairo::<Blake2sMerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
         }
 
         // TODO(Ohad): remove ignore.
@@ -362,6 +386,7 @@ pub mod tests {
                         &prove_cairo::<Blake2sMerkleChannel>(
                             test_basic_cairo_air_input(),
                             test_cfg(),
+                            PcsConfig::default(),
                         )
                         .unwrap(),
                     )
@@ -401,15 +426,19 @@ pub mod tests {
             fn test_prove_verify_all_builtins() {
                 let input = generate_test_input("test_prove_verify_all_builtins");
                 assert_all_builtins_in_input(&input);
-                let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, test_cfg()).unwrap();
-                verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
+                let cairo_proof =
+                    prove_cairo::<Blake2sMerkleChannel>(input, test_cfg(), PcsConfig::default())
+                        .unwrap();
+                verify_cairo::<Blake2sMerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
             }
 
             #[test]
             fn test_prove_verify_add_mod_builtin() {
                 let input = generate_test_input("test_prove_verify_add_mod_builtin");
-                let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, test_cfg()).unwrap();
-                verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
+                let cairo_proof =
+                    prove_cairo::<Blake2sMerkleChannel>(input, test_cfg(), PcsConfig::default())
+                        .unwrap();
+                verify_cairo::<Blake2sMerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
             }
 
             /// Asserts that there is an unused `add` value in the first instance in bitwise
@@ -437,29 +466,37 @@ pub mod tests {
                     "test_prove_verify_bitwise_builtin",
                     &input.builtins_segments.bitwise,
                 );
-                let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, test_cfg()).unwrap();
-                verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
+                let cairo_proof =
+                    prove_cairo::<Blake2sMerkleChannel>(input, test_cfg(), PcsConfig::default())
+                        .unwrap();
+                verify_cairo::<Blake2sMerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
             }
 
             #[test]
             fn test_prove_verify_mul_mod_builtin() {
                 let input = generate_test_input("test_prove_verify_mul_mod_builtin");
-                let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, test_cfg()).unwrap();
-                verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
+                let cairo_proof =
+                    prove_cairo::<Blake2sMerkleChannel>(input, test_cfg(), PcsConfig::default())
+                        .unwrap();
+                verify_cairo::<Blake2sMerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
             }
 
             #[test]
             fn test_prove_verify_range_check_bits_96_builtin() {
                 let input = generate_test_input("test_prove_verify_range_check_bits_96_builtin");
-                let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, test_cfg()).unwrap();
-                verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
+                let cairo_proof =
+                    prove_cairo::<Blake2sMerkleChannel>(input, test_cfg(), PcsConfig::default())
+                        .unwrap();
+                verify_cairo::<Blake2sMerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
             }
 
             #[test]
             fn test_prove_verify_range_check_bits_128_builtin() {
                 let input = generate_test_input("test_prove_verify_range_check_bits_128_builtin");
-                let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, test_cfg()).unwrap();
-                verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
+                let cairo_proof =
+                    prove_cairo::<Blake2sMerkleChannel>(input, test_cfg(), PcsConfig::default())
+                        .unwrap();
+                verify_cairo::<Blake2sMerkleChannel>(cairo_proof, PcsConfig::default()).unwrap();
             }
         }
     }

--- a/stwo_cairo_prover/crates/recursion_bridge/src/proof_generation/mod.rs
+++ b/stwo_cairo_prover/crates/recursion_bridge/src/proof_generation/mod.rs
@@ -5,6 +5,7 @@ mod tests {
     use cairo_lang_casm::casm;
     use stwo_cairo_adapter::plain::input_from_plain_casm_with_step_limit;
     use stwo_cairo_prover::cairo_air::{prove_cairo, verify_cairo, ProverConfig};
+    use stwo_prover::core::pcs::PcsConfig;
     use stwo_prover::core::vcs::blake2_merkle::Blake2sMerkleChannel;
 
     pub fn project_root() -> PathBuf {
@@ -21,11 +22,16 @@ mod tests {
         .instructions;
 
         let input = input_from_plain_casm_with_step_limit(instructions, 14);
-        let proof = prove_cairo::<Blake2sMerkleChannel>(input, ProverConfig::default()).unwrap();
+        let proof = prove_cairo::<Blake2sMerkleChannel>(
+            input,
+            ProverConfig::default(),
+            PcsConfig::default(),
+        )
+        .unwrap();
 
         let path = project_root().join("artifacts/jrl0_proof.json");
         std::fs::write(path, serde_json::to_string(&proof).unwrap()).unwrap();
 
-        verify_cairo::<Blake2sMerkleChannel>(proof).unwrap();
+        verify_cairo::<Blake2sMerkleChannel>(proof, PcsConfig::default()).unwrap();
     }
 }

--- a/stwo_cairo_prover/crates/run_and_prove/src/main.rs
+++ b/stwo_cairo_prover/crates/run_and_prove/src/main.rs
@@ -5,7 +5,8 @@ use clap::Parser;
 use stwo_cairo_adapter::plain::adapt_finished_runner;
 use stwo_cairo_adapter::vm_import::VmImportError;
 use stwo_cairo_prover::cairo_air::{
-    prove_cairo, verify_cairo, CairoVerificationError, ConfigBuilder,
+    default_prod_prover_parameters, prove_cairo, verify_cairo, CairoVerificationError,
+    ConfigBuilder, ProverParameters,
 };
 use stwo_cairo_utils::binary_utils::run_binary;
 use stwo_cairo_utils::vm_utils::{run_vm, VmArgs, VmError};
@@ -78,13 +79,15 @@ fn run(args: impl Iterator<Item = String>) -> Result<(), Error> {
         cairo_input.state_transitions.casm_states_by_opcode
     );
 
+    let ProverParameters { pcs_config } = default_prod_prover_parameters();
+
     // TODO(Ohad): Propagate hash from CLI args.
-    let proof = prove_cairo::<Blake2sMerkleChannel>(cairo_input, prover_config)?;
+    let proof = prove_cairo::<Blake2sMerkleChannel>(cairo_input, prover_config, pcs_config)?;
 
     std::fs::write(args.proof_path, serde_json::to_string(&proof)?)?;
 
     if args.verify {
-        verify_cairo::<Blake2sMerkleChannel>(proof)?;
+        verify_cairo::<Blake2sMerkleChannel>(proof, pcs_config)?;
         log::info!("Proof verified successfully");
     }
 


### PR DESCRIPTION
Why: currently there's no way to change PCS config externally, plus the default parameters set to 15 bits which may mislead ppl benchmarking programs with Stwo (e.g. in terms of the proof size).

What:
- `ProverParameters` struct is introduced (similarly to Stone which has prover config and prover params)
- A new CLI optional argument is introduced
- Default prover parameters chosen to ensure 96 bits of security and to keep the same proving time (prioritize speed over proof size)

This PR depends on #419 
Related to #410

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/420)
<!-- Reviewable:end -->
