### PR TITLE
Set channel hash via prover parameters file

### DIFF
--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "log",
+ "serde",
  "serde_json",
  "stwo-cairo-adapter",
  "stwo-prover",
@@ -709,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "faststr"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9154486833a83cb5d99de8c4d831314b8ae810dd4ef18d89ceb7a9c7c728dd74"
+checksum = "16c6338e632ed4711dd1327f6dc607e72e3f02a591ddd46f2bbee878f2d93c65"
 dependencies = [
  "bytes",
  "rkyv",

--- a/stwo_cairo_prover/crates/adapted_prover/Cargo.toml
+++ b/stwo_cairo_prover/crates/adapted_prover/Cargo.toml
@@ -9,6 +9,7 @@ std = ["stwo-cairo-adapter/std"]
 [dependencies]
 clap.workspace = true
 log.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 stwo_cairo_prover.workspace = true
 stwo_cairo_utils.workspace = true

--- a/stwo_cairo_prover/crates/prover/src/cairo_air/prover.rs
+++ b/stwo_cairo_prover/crates/prover/src/cairo_air/prover.rs
@@ -112,17 +112,32 @@ pub struct ProverConfig {
 
 /// Concrete parameters of the proving system.
 /// Used both for producing and verifying proofs.
-#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct ProverParameters {
+    /// Channel hash function.
+    pub channel_hash: ChannelHash,
     /// Parameters of the commitment scheme.
     pub pcs_config: PcsConfig,
-    // TODO(m-kus): add channel hash type here
+}
+
+/// The hash function used for commitments, for the prover-verifier channel,
+/// and for PoW grinding.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelHash {
+    /// Default variant, the fastest option.
+    Blake2s,
+    /// A variant for recursive proof verification.
+    /// Note that using `Poseidon252` results in a significant decrease in proving speed compared
+    /// to `Blake2s` (because of the large field emulation)
+    Poseidon252,
 }
 
 /// The default prover parameters for prod use (96 bits of security).
 /// The formula is `security_bits = pow_bits + log_blowup_factor * n_queries`.
 pub fn default_prod_prover_parameters() -> ProverParameters {
     ProverParameters {
+        channel_hash: ChannelHash::Blake2s,
         pcs_config: PcsConfig {
             // Stay within 500ms on M3.
             pow_bits: 26,

--- a/stwo_cairo_prover/crates/run_and_prove/src/main.rs
+++ b/stwo_cairo_prover/crates/run_and_prove/src/main.rs
@@ -76,7 +76,10 @@ fn run(args: impl Iterator<Item = String>) -> Result<(), Error> {
         cairo_input.state_transitions.casm_states_by_opcode
     );
 
-    let ProverParameters { pcs_config } = default_prod_prover_parameters();
+    let ProverParameters {
+        channel_hash: _,
+        pcs_config,
+    } = default_prod_prover_parameters();
 
     // TODO(Ohad): Propagate hash from CLI args.
     let proof = prove_cairo::<Blake2sMerkleChannel>(cairo_input, prover_config, pcs_config)?;


### PR DESCRIPTION
Why: currently there's no way to parameterize the channel hash externally, though it's handy for e.g. testing recursion

What:
- `channel_hash` field is added to prover parameters, can be either `blake2s` or `poseidon252`
- `adapted_stwo` invokes generic prove/verify methods taking into account the channel hash setting

Depends on #420 
Related to #410

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/422)
<!-- Reviewable:end -->
