### PR TITLE
Avoid panics when generating prover input from Cairo runner

### DIFF
--- a/stwo_cairo_prover/crates/prover/src/adapter/vm_import/mod.rs
+++ b/stwo_cairo_prover/crates/prover/src/adapter/vm_import/mod.rs
@@ -33,6 +33,12 @@ pub enum VmImportError {
     Json(#[from] sonic_rs::Error),
     #[error("No memory segments")]
     NoMemorySegments,
+
+    #[error("Trace not relocated")]
+    TraceNotRelocated,
+
+    #[error("Cannot get public input from runner: {0}")]
+    PublicInput(#[from] cairo_vm::air_public_input::PublicInputError),
 }
 
 fn deserialize_inputs<'a>(

--- a/stwo_cairo_prover/crates/run_and_prove/src/main.rs
+++ b/stwo_cairo_prover/crates/run_and_prove/src/main.rs
@@ -64,7 +64,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<(), Error> {
     let _span = span!(Level::INFO, "run").entered();
     let args = Args::try_parse_from(args)?;
     let cairo_runner = run_vm(&args.vm_args)?;
-    let cairo_input = adapt_finished_runner(cairo_runner);
+    let cairo_input = adapt_finished_runner(cairo_runner)?;
     let prover_config = ConfigBuilder::default()
         .track_relations(args.track_relations)
         .display_components(args.display_components)


### PR DESCRIPTION
Why: `adapt_finished_runner` method is useful to pass the Cairo executor results to the prover directly (without going through file io), it can be utilized externally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/456)
<!-- Reviewable:end -->
