### PR TITLE
disable pad_builtin_segments when adapt_to_stwo_input is run not in proof_mode

### DIFF
--- a/stwo_cairo_prover/crates/adapted_prover/src/main.rs
+++ b/stwo_cairo_prover/crates/adapted_prover/src/main.rs
@@ -72,7 +72,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<(), Error> {
     let args = Args::try_parse_from(args)?;
 
     let vm_output: ProverInput =
-        adapt_vm_output(args.pub_json.as_path(), args.priv_json.as_path())?;
+        adapt_vm_output(args.pub_json.as_path(), args.priv_json.as_path(), true)?;
     let prover_config = ConfigBuilder::default()
         .track_relations(args.track_relations)
         .display_components(args.display_components)

--- a/stwo_cairo_prover/crates/prover/src/adapter/plain.rs
+++ b/stwo_cairo_prover/crates/prover/src/adapter/plain.rs
@@ -26,7 +26,7 @@ pub fn input_from_plain_casm(casm: Vec<cairo_lang_casm::instructions::Instructio
         )
         .expect("Run failed");
     runner.relocate(true).unwrap();
-    adapt_finished_runner(runner).expect("Failed to adapt finished runner")
+    adapt_finished_runner(runner, true).expect("Failed to adapt finished runner")
 }
 
 // NOTE: the proof will include `step_limit -1` steps.
@@ -44,7 +44,7 @@ pub fn input_from_plain_casm_with_step_limit(
         .expect("Run failed");
     runner.relocate(true).unwrap();
 
-    adapt_finished_runner(runner).expect("Failed to adapt finished runner")
+    adapt_finished_runner(runner, true).expect("Failed to adapt finished runner")
 }
 
 fn program_from_casm(
@@ -75,7 +75,10 @@ fn program_from_casm(
 /// input to the adapter.
 /// When dev mod is enabled, the opcodes generated from the plain casm will be mapped to the generic
 /// component only.
-pub fn adapt_finished_runner(runner: CairoRunner) -> Result<ProverInput, VmImportError> {
+pub fn adapt_finished_runner(
+    runner: CairoRunner,
+    proof_mode: bool,
+) -> Result<ProverInput, VmImportError> {
     let _span = tracing::info_span!("adapt_finished_runner").entered();
     let memory_iter = runner
         .relocated_memory
@@ -109,5 +112,6 @@ pub fn adapt_finished_runner(runner: CairoRunner) -> Result<ProverInput, VmImpor
         MemoryBuilder::from_iter(MemoryConfig::default(), memory_iter),
         public_memory_addresses,
         memory_segments,
+        proof_mode,
     )
 }

--- a/stwo_cairo_prover/crates/prover/src/cairo_air/mod.rs
+++ b/stwo_cairo_prover/crates/prover/src/cairo_air/mod.rs
@@ -249,12 +249,17 @@ pub mod tests {
     ///
     /// # Panics
     /// - If it fails to convert the files into a prover input.
-    pub fn test_input(test_name: &str) -> ProverInput {
+    pub fn test_input(test_name: &str, proof_mode: bool) -> ProverInput {
         let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         d.push("test_data/");
         d.push(test_name);
 
-        adapt_vm_output(d.join("pub.json").as_path(), d.join("priv.json").as_path()).expect(
+        adapt_vm_output(
+            d.join("pub.json").as_path(),
+            d.join("priv.json").as_path(),
+            proof_mode,
+        )
+        .expect(
             "
             Failed to read test files. Checkout input/README.md.",
         )
@@ -334,7 +339,7 @@ pub mod tests {
         #[test]
         fn test_full_cairo_air() {
             let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(
-                test_input("test_read_from_small_files"),
+                test_input("test_read_from_small_files", true),
                 test_cfg(),
             )
             .unwrap();
@@ -343,7 +348,7 @@ pub mod tests {
 
         #[test]
         fn test_prove_verify_all_opcode_components() {
-            let input = test_input("test_prove_verify_all_opcode_components");
+            let input = test_input("test_prove_verify_all_opcode_components", true);
             for (opcode, n_instances) in input.state_transitions.casm_states_by_opcode.counts() {
                 // TODO(Stav): Remove when `Blake` opcode is in the VM.
                 if opcode == "blake2s_opcode" {
@@ -362,7 +367,7 @@ pub mod tests {
                 );
             }
             let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(
-                test_input("test_prove_verify_all_opcode_components"),
+                test_input("test_prove_verify_all_opcode_components", true),
                 test_cfg(),
             )
             .unwrap();
@@ -418,7 +423,7 @@ pub mod tests {
 
             #[test]
             fn test_prove_verify_all_builtins() {
-                let input = test_input("test_prove_verify_all_builtins");
+                let input = test_input("test_prove_verify_all_builtins", true);
                 assert_all_builtins_in_input(&input);
                 let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, test_cfg()).unwrap();
                 verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
@@ -426,7 +431,7 @@ pub mod tests {
 
             #[test]
             fn test_prove_verify_add_mod_builtin() {
-                let input = test_input("test_prove_verify_add_mod_builtin");
+                let input = test_input("test_prove_verify_add_mod_builtin", true);
                 let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, test_cfg()).unwrap();
                 verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
             }
@@ -451,7 +456,7 @@ pub mod tests {
 
             #[test]
             fn test_prove_verify_bitwise_builtin() {
-                let input = test_input("test_prove_verify_bitwise_builtin");
+                let input = test_input("test_prove_verify_bitwise_builtin", true);
                 assert_bitwise_builtin_has_holes(
                     "test_prove_verify_bitwise_builtin",
                     &input.builtins_segments.bitwise,
@@ -462,21 +467,21 @@ pub mod tests {
 
             #[test]
             fn test_prove_verify_mul_mod_builtin() {
-                let input = test_input("test_prove_verify_mul_mod_builtin");
+                let input = test_input("test_prove_verify_mul_mod_builtin", true);
                 let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, test_cfg()).unwrap();
                 verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
             }
 
             #[test]
             fn test_prove_verify_range_check_bits_96_builtin() {
-                let input = test_input("test_prove_verify_range_check_bits_96_builtin");
+                let input = test_input("test_prove_verify_range_check_bits_96_builtin", true);
                 let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, test_cfg()).unwrap();
                 verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
             }
 
             #[test]
             fn test_prove_verify_range_check_bits_128_builtin() {
-                let input = test_input("test_prove_verify_range_check_bits_128_builtin");
+                let input = test_input("test_prove_verify_range_check_bits_128_builtin", true);
                 let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, test_cfg()).unwrap();
                 verify_cairo::<Blake2sMerkleChannel>(cairo_proof).unwrap();
             }

--- a/stwo_cairo_prover/crates/run_and_prove/src/main.rs
+++ b/stwo_cairo_prover/crates/run_and_prove/src/main.rs
@@ -64,7 +64,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<(), Error> {
     let _span = span!(Level::INFO, "run").entered();
     let args = Args::try_parse_from(args)?;
     let cairo_runner = run_vm(&args.vm_args)?;
-    let cairo_input = adapt_finished_runner(cairo_runner)?;
+    let cairo_input = adapt_finished_runner(cairo_runner, args.vm_args.proof_mode)?;
     let prover_config = ConfigBuilder::default()
         .track_relations(args.track_relations)
         .display_components(args.display_components)

--- a/stwo_cairo_prover/crates/vm_runner/src/main.rs
+++ b/stwo_cairo_prover/crates/vm_runner/src/main.rs
@@ -48,7 +48,7 @@ fn run(args: impl Iterator<Item = String>) -> Result<ProverInput, Error> {
     let _span = span!(Level::INFO, "run").entered();
     let args = Args::try_parse_from(args)?;
     let cairo_runner = run_vm(&args.vm_args)?;
-    let cairo_input = adapt_finished_runner(cairo_runner)?;
+    let cairo_input = adapt_finished_runner(cairo_runner, false)?;
 
     let execution_resources = ExecutionResources::from_prover_input(&cairo_input);
     log::info!("Execution resources: {:#?}", execution_resources);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/536)
<!-- Reviewable:end -->
