### PR TITLE
externalize QM31 from stwo_prover via prover_types so that it can be used in stwo-air-infra

### DIFF
--- a/stwo_cairo_prover/crates/common/src/prover_types/cpu.rs
+++ b/stwo_cairo_prover/crates/common/src/prover_types/cpu.rs
@@ -7,6 +7,7 @@ use starknet_ff::FieldElement;
 use stwo_cairo_serialize::CairoSerialize;
 
 pub type M31 = stwo_prover::core::fields::m31::M31;
+pub type QM31 = stwo_prover::core::fields::qm31::QM31;
 
 pub const PRIME: u32 = 2_u32.pow(31) - 1;
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/544)
<!-- Reviewable:end -->
