### PR TITLE
fix broken main due to changes in cairo-vm

### DIFF
--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -1792,6 +1792,7 @@ dependencies = [
  "stwo-cairo-common",
  "stwo-prover",
  "thiserror 2.0.11",
+ "thiserror-no-std",
  "tracing",
 ]
 

--- a/stwo_cairo_prover/crates/adapter/Cargo.toml
+++ b/stwo_cairo_prover/crates/adapter/Cargo.toml
@@ -20,6 +20,7 @@ bytemuck.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 sonic-rs = { version = "0.3.17", optional = true }
+thiserror-no-std = { version = "2.0.2", default-features = false }
 
 [dev-dependencies]
 cairo-lang-casm.workspace = true

--- a/stwo_cairo_prover/crates/adapter/src/lib.rs
+++ b/stwo_cairo_prover/crates/adapter/src/lib.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use builtins::BuiltinSegments;
+use cairo_vm::stdlib::collections::HashMap;
 use cairo_vm::types::builtin_name::BuiltinName;
 use memory::Memory;
 use opcodes::StateTransitions;

--- a/stwo_cairo_prover/crates/adapter/src/memory.rs
+++ b/stwo_cairo_prover/crates/adapter/src/memory.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
+use cairo_vm::stdlib::collections::HashMap;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use stwo_cairo_common::memory::{N_BITS_PER_FELT, N_M31_IN_SMALL_FELT252};

--- a/stwo_cairo_prover/crates/adapter/src/opcodes.rs
+++ b/stwo_cairo_prover/crates/adapter/src/opcodes.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
 use std::fmt::Display;
 
+use cairo_vm::stdlib::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use stwo_cairo_common::prover_types::cpu::CasmState;
 use stwo_prover::core::fields::m31::M31;

--- a/stwo_cairo_prover/crates/adapter/src/vm_import/mod.rs
+++ b/stwo_cairo_prover/crates/adapter/src/vm_import/mod.rs
@@ -5,12 +5,12 @@ use std::io::Read;
 use std::path::Path;
 
 use bytemuck::{bytes_of_mut, Pod, Zeroable};
-use cairo_vm::air_public_input::{MemorySegmentAddresses, PublicInput};
+use cairo_vm::air_public_input::{MemorySegmentAddresses, PublicInput, PublicInputError};
 use cairo_vm::stdlib::collections::HashMap;
 use cairo_vm::vm::trace::trace_entry::RelocatedTraceEntry;
 use json::PrivateInput;
 use stwo_cairo_common::memory::MEMORY_ADDRESS_BOUND;
-use thiserror::Error;
+use thiserror_no_std::Error;
 use tracing::{span, Level};
 
 use super::builtins::BuiltinSegments;
@@ -35,7 +35,7 @@ pub enum VmImportError {
     TraceNotRelocated,
 
     #[error("Cannot get public input from runner: {0}")]
-    PublicInput(#[from] cairo_vm::air_public_input::PublicInputError),
+    PublicInput(#[from] PublicInputError),
 }
 
 fn deserialize_inputs<'a>(


### PR DESCRIPTION
Changed dependencies to match cairo-vm rust. 

And that's why we don't want to replicate structs from there

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/609)
<!-- Reviewable:end -->
