### PR TITLE
Use SIMD in adapter::memory::value_from_felt252

### DIFF
--- a/stwo_cairo_prover/crates/adapter/src/builtins.rs
+++ b/stwo_cairo_prover/crates/adapter/src/builtins.rs
@@ -218,14 +218,14 @@ impl BuiltinSegments {
         }
     }
 
-    pub fn pad_relocatble_builtin_segments(
+    pub fn pad_relocatable_builtin_segments(
         relocatable_memory: &mut [Vec<Option<MaybeRelocatable>>],
         builtins_segments: BTreeMap<usize, BuiltinName>,
     ) {
         for (segment_index, builtin_name) in builtins_segments {
-            let current_buitlin_segment = &mut relocatable_memory[segment_index];
+            let current_builtin_segment = &mut relocatable_memory[segment_index];
 
-            let original_segment_len = current_buitlin_segment.len();
+            let original_segment_len = current_builtin_segment.len();
 
             if original_segment_len == 0 {
                 // Do not pad empty segments.
@@ -256,13 +256,13 @@ impl BuiltinSegments {
                 .next_power_of_two()
                 .max(MIN_SEGMENT_SIZE)
                 * cells_per_instance;
-            current_buitlin_segment.resize(new_segment_size, None);
+            current_builtin_segment.resize(new_segment_size, None);
 
             // Fill the segment extension with copies of the last instance.
             let last_instance_start = original_segment_len - cells_per_instance;
             for i in original_segment_len..new_segment_size {
-                current_buitlin_segment[i] =
-                    current_buitlin_segment[last_instance_start + (i % cells_per_instance)].clone();
+                current_builtin_segment[i] =
+                    current_builtin_segment[last_instance_start + (i % cells_per_instance)].clone();
             }
         }
     }
@@ -604,7 +604,7 @@ mod test_builtin_segments {
     }
 
     #[test]
-    fn test_pad_relocatble_builtin_segments() {
+    fn test_pad_relocatable_builtin_segments() {
         let bitwise_instance = [787, 365, 257, 895, 638, 55, 102, 3, 4, 7];
         let segment0 = bitwise_instance
             .iter()
@@ -630,7 +630,7 @@ mod test_builtin_segments {
         let builtins_segments =
             BTreeMap::from([(0, BuiltinName::bitwise), (1, BuiltinName::ec_op)]);
 
-        BuiltinSegments::pad_relocatble_builtin_segments(
+        BuiltinSegments::pad_relocatable_builtin_segments(
             &mut relocatable_memory,
             builtins_segments,
         );

--- a/stwo_cairo_prover/crates/adapter/src/lib.rs
+++ b/stwo_cairo_prover/crates/adapter/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(portable_simd)]
 use builtins::BuiltinSegments;
 pub use cairo_vm::stdlib::collections::HashMap;
 use cairo_vm::types::builtin_name::BuiltinName;

--- a/stwo_cairo_prover/crates/adapter/src/memory.rs
+++ b/stwo_cairo_prover/crates/adapter/src/memory.rs
@@ -1,5 +1,7 @@
 use std::io::Read;
 use std::ops::{Deref, DerefMut};
+use std::simd::prelude::SimdPartialEq;
+use std::simd::u32x8;
 
 use bytemuck::{bytes_of_mut, Pod, Zeroable};
 use cairo_vm::stdlib::collections::HashMap;
@@ -111,9 +113,20 @@ impl Memory {
     }
 }
 
-// TODO(spapini): Optimize. This should be SIMD.
+/// Converts an F252 (represented as [u32; 8]) to a MemoryValue,
+/// using SIMD instructions for the condition check.
 pub fn value_from_felt252(felt252: F252) -> MemoryValue {
-    if felt252[3..8] == [0; 5] && felt252[2] < (1 << 8) {
+    let v = u32x8::from_array(felt252);
+    let zeros = u32x8::splat(0);
+    let eq_zero_mask = v.simd_eq(zeros);
+    let mask_bits = eq_zero_mask.to_bitmask();
+
+    const UPPER_LANES_ZERO_BITS: u64 = 0b11111000;
+    let upper_lanes_are_zero = (mask_bits & UPPER_LANES_ZERO_BITS) == UPPER_LANES_ZERO_BITS;
+
+    let limb2_is_small = felt252[2] < 256; // 1 << 8
+
+    if upper_lanes_are_zero && limb2_is_small {
         MemoryValue::Small(
             felt252[0] as u128
                 + ((felt252[1] as u128) << 32)
@@ -409,18 +422,18 @@ mod tests {
                 value: [1, 2, 0, 0, 0, 0, 0, 0],
             },
         ];
-        let expxcted_id_addr_0 = EncodedMemoryValueId::encode(MemoryValueId::F252(0));
-        let expxcted_id_addr_1 = EncodedMemoryValueId::default();
-        let expxcted_id_addr_2 = EncodedMemoryValueId::encode(MemoryValueId::Small(0));
+        let expected_id_addr_0 = EncodedMemoryValueId::encode(MemoryValueId::F252(0));
+        let expected_id_addr_1 = EncodedMemoryValueId::default();
+        let expected_id_addr_2 = EncodedMemoryValueId::encode(MemoryValueId::Small(0));
 
         let memory = MemoryBuilder::from_iter(MemoryConfig::default(), entries).build();
         let addr_0_id = memory.address_to_id[0];
         let addr_1_id = memory.address_to_id[1];
         let addr_2_id = memory.address_to_id[2];
 
-        assert_eq!(addr_0_id, expxcted_id_addr_0);
-        assert_eq!(addr_1_id, expxcted_id_addr_1);
-        assert_eq!(addr_2_id, expxcted_id_addr_2);
+        assert_eq!(addr_0_id, expected_id_addr_0);
+        assert_eq!(addr_1_id, expected_id_addr_1);
+        assert_eq!(addr_2_id, expected_id_addr_2);
     }
 
     #[test]
@@ -461,5 +474,58 @@ mod tests {
         memory_builder.set(2, MemoryValue::Small(123));
 
         memory_builder.assert_segment_is_empty(0, 4);
+    }
+
+    #[test]
+    fn test_value_from_felt252() {
+        // Case 1: Should be Small (limbs 3-7 zero, limb 2 < 256)
+        let felt_small = [1, 2, 3, 0, 0, 0, 0, 0];
+        let expected_small_val = 1u128 + (2u128 << 32) + (3u128 << 64);
+        assert_eq!(
+            value_from_felt252(felt_small), // Test scalar version
+            MemoryValue::Small(expected_small_val)
+        );
+
+        // Case 2: Should be F252 (limb 3 non-zero)
+        let felt_large_limb3 = [1, 2, 3, 4, 0, 0, 0, 0];
+        assert_eq!(
+            value_from_felt252(felt_large_limb3),
+            MemoryValue::F252(felt_large_limb3)
+        );
+
+        // Case 3: Should be F252 (limb 7 non-zero)
+        let felt_large_limb7 = [1, 2, 3, 0, 0, 0, 0, 10];
+        assert_eq!(
+            value_from_felt252(felt_large_limb7),
+            MemoryValue::F252(felt_large_limb7)
+        );
+
+        // Case 4: Should be F252 (limb 2 >= 256)
+        let felt_large_limb2 = [1, 2, 256, 0, 0, 0, 0, 0];
+        assert_eq!(
+            value_from_felt252(felt_large_limb2),
+            MemoryValue::F252(felt_large_limb2)
+        );
+
+        // Case 5: Boundary - Should be Small (limb 2 == 255)
+        let felt_small_boundary = [1, 2, 255, 0, 0, 0, 0, 0];
+        let expected_small_boundary_val = 1u128 + (2u128 << 32) + (255u128 << 64);
+        assert_eq!(
+            value_from_felt252(felt_small_boundary),
+            MemoryValue::Small(expected_small_boundary_val)
+        );
+
+        // Case 6: Zero value
+        let felt_zero = [0; 8];
+        assert_eq!(value_from_felt252(felt_zero), MemoryValue::Small(0));
+
+        // Case 7: Max small value representation within limits
+        let felt_max_small_limb = [u32::MAX, u32::MAX, 255, 0, 0, 0, 0, 0];
+        let expected_max_small_val =
+            (u32::MAX as u128) + ((u32::MAX as u128) << 32) + (255u128 << 64);
+        assert_eq!(
+            value_from_felt252(felt_max_small_limb),
+            MemoryValue::Small(expected_max_small_val)
+        );
     }
 }

--- a/stwo_cairo_prover/crates/adapter/src/opcodes.rs
+++ b/stwo_cairo_prover/crates/adapter/src/opcodes.rs
@@ -17,7 +17,7 @@ const SMALL_ADD_MIN_VALUE: i32 = -(2_i32.pow(27));
 const SMALL_MUL_MAX_VALUE: u64 = 2_u64.pow(36) - 1;
 const SMALL_MUL_MIN_VALUE: u64 = 0;
 
-// TODO (Stav): Ensure it stays synced with that opcdode AIR's list.
+// TODO (Stav): Ensure it stays synced with that opcode AIR's list.
 /// This struct holds the components used to prove the opcodes in a Cairo program,
 /// and should match the opcode's air used by `stwo-cairo-air`.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]

--- a/stwo_cairo_prover/crates/adapter/src/plain.rs
+++ b/stwo_cairo_prover/crates/adapter/src/plain.rs
@@ -95,7 +95,7 @@ pub fn adapt_finished_runner(runner: CairoRunner) -> Result<ProverInput, VmImpor
 pub fn prover_input_info_to_prover_input(
     prover_input_info: &mut ProverInputInfo,
 ) -> Result<ProverInput, VmImportError> {
-    BuiltinSegments::pad_relocatble_builtin_segments(
+    BuiltinSegments::pad_relocatable_builtin_segments(
         &mut prover_input_info.relocatable_memory,
         prover_input_info.builtins_segments.clone(),
     );

--- a/stwo_cairo_prover/crates/prover/src/witness/components/memory_address_to_id.rs
+++ b/stwo_cairo_prover/crates/prover/src/witness/components/memory_address_to_id.rs
@@ -85,9 +85,8 @@ impl ClaimGenerator {
     }
 
     pub fn deduce_output(&self, input: PackedBaseField) -> PackedBaseField {
-        let indices = input.to_array().map(|i| i.0);
-        let memory_ids = std::array::from_fn(|j| self.get_id(M31(indices[j])));
-        PackedBaseField::from_array(memory_ids)
+        let ids = input.to_array().map(|i| self.get_id(i));
+        PackedBaseField::from_array(ids)
     }
 
     pub fn get_id(&self, input: BaseField) -> M31 {


### PR DESCRIPTION
- **Typos**
- **Use SIMD to check felt252 is small**

Benchmarks that I didn't commit gave me:

```
value_from_felt252/Scalar/mixed
                        time:   [2.1954 µs 2.2091 µs 2.2282 µs]
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe
value_from_felt252/SIMD/mixed
                        time:   [1.5052 µs 1.5079 µs 1.5109 µs]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
```

i.e. 2.2 / 1.5 = ~1,47 improvement
