### PR TITLE
feat: import no_std hashmaps

### DIFF
--- a/stwo_cairo_prover/crates/adapter/src/test_utils.rs
+++ b/stwo_cairo_prover/crates/adapter/src/test_utils.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
 use std::fs::{read, read_to_string, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use cairo_vm::cairo_run::{cairo_run, CairoRunConfig};
 use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::*;
+use cairo_vm::stdlib::collections::HashMap;
 use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::types::relocatable::MaybeRelocatable;
 use cairo_vm::vm::runners::cairo_runner::{CairoRunner, ProverInputInfo};

--- a/stwo_cairo_prover/crates/cairo-air/src/air.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/air.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
-
 use itertools::{chain, Itertools};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
+use stwo_cairo_adapter::HashMap;
 use stwo_cairo_common::prover_types::cpu::CasmState;
 use stwo_cairo_common::prover_types::felt::split_f252;
 use stwo_cairo_serialize::CairoSerialize;
@@ -843,7 +842,7 @@ impl std::fmt::Display for CairoComponents {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use stwo_cairo_adapter::HashMap;
 
     use crate::air::accumulate_relation_uses;
     use crate::verifier::RelationUse;

--- a/stwo_cairo_prover/crates/cairo-air/src/blake/air.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/blake/air.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
+use stwo_cairo_adapter::HashMap;
 use stwo_cairo_serialize::CairoSerialize;
 use stwo_prover::constraint_framework::TraceLocationAllocator;
 use stwo_prover::core::air::ComponentProver;

--- a/stwo_cairo_prover/crates/cairo-air/src/builtins_air.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/builtins_air.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
-
 use itertools::chain;
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
+use stwo_cairo_adapter::HashMap;
 use stwo_cairo_serialize::CairoSerialize;
 use stwo_prover::constraint_framework::TraceLocationAllocator;
 use stwo_prover::core::air::ComponentProver;

--- a/stwo_cairo_prover/crates/cairo-air/src/opcodes_air.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/opcodes_air.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
-
 use itertools::{chain, Itertools};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
+use stwo_cairo_adapter::HashMap;
 use stwo_cairo_serialize::CairoSerialize;
 use stwo_prover::constraint_framework::TraceLocationAllocator;
 use stwo_prover::core::air::ComponentProver;

--- a/stwo_cairo_prover/crates/cairo-air/src/pedersen/air.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/pedersen/air.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use num_traits::Zero;
+use stwo_cairo_adapter::HashMap;
 use stwo_prover::constraint_framework::TraceLocationAllocator;
 use stwo_prover::core::air::ComponentProver;
 use stwo_prover::core::backend::simd::SimdBackend;

--- a/stwo_cairo_prover/crates/cairo-air/src/poseidon/air.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/poseidon/air.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use num_traits::Zero;
+use stwo_cairo_adapter::HashMap;
 use stwo_prover::constraint_framework::TraceLocationAllocator;
 use stwo_prover::core::air::ComponentProver;
 use stwo_prover::core::backend::simd::SimdBackend;

--- a/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
@@ -1,11 +1,10 @@
-use std::collections::HashMap;
-
 use num_traits::{One, Zero};
 use paste::paste;
 use stwo_cairo_adapter::builtins::{
     ADD_MOD_MEMORY_CELLS, BITWISE_MEMORY_CELLS, MUL_MOD_MEMORY_CELLS, PEDERSEN_MEMORY_CELLS,
     POSEIDON_MEMORY_CELLS, RANGE_CHECK_MEMORY_CELLS,
 };
+use stwo_cairo_adapter::HashMap;
 use stwo_cairo_common::memory::LOG_MEMORY_ADDRESS_BOUND;
 use stwo_cairo_common::prover_types::cpu::{CasmState, PRIME};
 use stwo_prover::constraint_framework::PREPROCESSED_TRACE_IDX;


### PR DESCRIPTION
slight change to import no_std compatible hashmaps in stwo_cairo_adapter and stwo-air crates

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/877)
<!-- Reviewable:end -->
