### PR TITLE
Cairo-prove: add --proof-format cli option and support cairo-serde

### DIFF
--- a/cairo-prove/Cargo.lock
+++ b/cairo-prove/Cargo.lock
@@ -1145,6 +1145,7 @@ dependencies = [
  "num-bigint",
  "serde_json",
  "stwo-cairo-adapter",
+ "stwo-cairo-serialize",
  "stwo_cairo_prover",
 ]
 

--- a/cairo-prove/Cargo.toml
+++ b/cairo-prove/Cargo.toml
@@ -8,6 +8,7 @@ stwo-cairo-adapter = { git = "https://github.com/starkware-libs/stwo-cairo", rev
     "std",
 ] }
 stwo_cairo_prover = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "b160127" }
+stwo-cairo-serialize = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "b160127" }
 cairo-air = { git = "https://github.com/starkware-libs/stwo-cairo", rev = "b160127" }
 cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "5cc466a" }
 cairo-lang-executable = { git = "https://github.com/starkware-libs/cairo.git", rev = "5cc466a" }

--- a/cairo-prove/src/args.rs
+++ b/cairo-prove/src/args.rs
@@ -21,6 +21,11 @@ pub enum Commands {
         target: PathBuf,
         /// Path to the proof file
         proof: PathBuf,
+        /// The format of the proof output.
+        /// - json: Standard JSON format (default)
+        /// - cairo_serde: Array of field elements serialized as hex strings, ex. `["0x1", "0x2"]`
+        #[arg(long, value_enum, default_value_t = ProofFormat::Json)]
+        proof_format: ProofFormat,
         /// Program arguments
         #[command(flatten)]
         program_arguments: ProgramArguments,
@@ -33,6 +38,15 @@ pub enum Commands {
         #[arg(short, long)]
         with_pedersen: bool,
     },
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum ProofFormat {
+    /// Standard JSON format.
+    Json,
+    /// Array of field elements serialized as hex strings.
+    /// Compatible with `scarb execute`
+    CairoSerde,
 }
 
 #[derive(Parser, Debug, Clone)]

--- a/cairo-prove/src/execute.rs
+++ b/cairo-prove/src/execute.rs
@@ -2,13 +2,13 @@ use std::collections::HashMap;
 
 use cairo_lang_casm::hints::Hint;
 use cairo_lang_executable::executable::{EntryPointKind, Executable};
-use cairo_lang_runner::{build_hints_dict, Arg, CairoHintProcessor};
-use cairo_vm::cairo_run::{cairo_run_program, CairoRunConfig};
+use cairo_lang_runner::{Arg, CairoHintProcessor, build_hints_dict};
+use cairo_vm::Felt252;
+use cairo_vm::cairo_run::{CairoRunConfig, cairo_run_program};
 use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::types::program::Program;
 use cairo_vm::types::relocatable::MaybeRelocatable;
 use cairo_vm::vm::runners::cairo_runner::CairoRunner;
-use cairo_vm::Felt252;
 use log::info;
 
 /// Executes a Cairo program and returns a `CairoRunner` that can be used to generate artifacts for

--- a/cairo-prove/src/prove.rs
+++ b/cairo-prove/src/prove.rs
@@ -5,7 +5,7 @@ use cairo_vm::vm::runners::cairo_runner::CairoRunner;
 use log::{debug, info};
 use stwo_cairo_adapter::builtins::MemorySegmentAddresses;
 use stwo_cairo_adapter::memory::{MemoryBuilder, MemoryConfig, MemoryEntry};
-use stwo_cairo_adapter::vm_import::{adapt_to_stwo_input, RelocatedTraceEntry};
+use stwo_cairo_adapter::vm_import::{RelocatedTraceEntry, adapt_to_stwo_input};
 use stwo_cairo_adapter::{ProverInput, PublicSegmentContext};
 use stwo_cairo_prover::stwo_prover::core::pcs::PcsConfig;
 use stwo_cairo_prover::stwo_prover::core::vcs::blake2_merkle::{


### PR DESCRIPTION
A switch that allows to serialize the proof with serde to use for recursion (in stwo-cairo-verifier)