### PR TITLE
Fix typos in comments

### DIFF
--- a/stwo_cairo_verifier/crates/cairo_air/src/lib.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/lib.cairo
@@ -1901,7 +1901,7 @@ fn verify_claim(claim: @CairoClaim) {
 
     // When using address_to_id relation, it is assumed that address < 2^27.
     // To verify that, one needs to check that the size of the address_to_id component <=
-    // 2^(27 - log2(MEMORY_ADDRESS_TO_ID_SPLIT)), beacuse the component is split to
+    // 2^(27 - log2(MEMORY_ADDRESS_TO_ID_SPLIT)), because the component is split to
     // MEMORY_ADDRESS_TO_ID_SPLIT addresses in each row of the component.
     assert!(pow2(LOG_MEMORY_ADDRESS_TO_ID_SPLIT) == MEMORY_ADDRESS_TO_ID_SPLIT);
     assert!(*claim.memory_address_to_id.log_size <= 27_u32 - LOG_MEMORY_ADDRESS_TO_ID_SPLIT);
@@ -2359,7 +2359,7 @@ impl OpcodeInteractionClaimImpl of OpcodeInteractionClaimTrait {
     }
 }
 
-// TODO(alonf) Change all the obscure types and structs to a meaninful struct system for the memory.
+// TODO(alonf) Change all the obscure types and structs to a meaningful struct system for the memory.
 #[derive(Clone, Debug, Serde, Copy, Drop)]
 pub struct MemorySmallValue {
     pub id: u32,


### PR DESCRIPTION


### PR Description

This pull request addresses two minor typographical errors found in the comments of the `stwo_cairo_verifier/crates/cairo_air/src/lib.cairo` file.

**Changes:**

*   Corrected `beacuse` to `because`.
*   Corrected `meaninful` to `meaningful`.

These changes improve code readability and maintainability by ensuring the comments are accurate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1023)
<!-- Reviewable:end -->
