### PR TITLE
update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/cairo-ci.yaml
+++ b/.github/workflows/cairo-ci.yaml
@@ -24,7 +24,7 @@ jobs:
       run:
         working-directory: ./stwo_cairo_verifier
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: "nightly-2025-05-17"
@@ -41,7 +41,7 @@ jobs:
       run:
         working-directory: ./stwo_cairo_prover
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential
       - name: Install Rust toolchain
@@ -68,7 +68,7 @@ jobs:
       run:
         working-directory: ./cairo-prove
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential
       - name: Install Rust toolchain
@@ -88,7 +88,7 @@ jobs:
       run:
         working-directory: ./stwo_cairo_prover
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
@@ -102,7 +102,7 @@ jobs:
       run:
         working-directory: ./stwo_cairo_prover
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           components: clippy


### PR DESCRIPTION
Updates actions/checkout to the latest stable version v4.

Changes:
- Updates all instances of actions/checkout@v3 to actions/checkout@v4
- This is the last file requiring this update, all other files have been updated

Reference:
Latest version confirmation: https://github.com/actions/checkout/releases/tag/v4.2.2

This update ensures we're using the most recent stable version of the GitHub checkout action across our CI/CD pipelines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1030)
<!-- Reviewable:end -->
