### PR TITLE
cairo-air: fix std feature propagation

### DIFF
--- a/stwo_cairo_prover/crates/adapter/Cargo.toml
+++ b/stwo_cairo_prover/crates/adapter/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 
 [features]
 slow-tests = []
-std = ["dep:sonic-rs"]
+# TODO(STAV): Delete this feature when the old adapter is removed.
+std = ["dep:sonic-rs", "cairo-vm/std"]
 
 [dependencies]
 bytemuck.workspace = true

--- a/stwo_cairo_prover/crates/cairo-air/Cargo.toml
+++ b/stwo_cairo_prover/crates/cairo-air/Cargo.toml
@@ -3,6 +3,9 @@ name = "cairo-air"
 version.workspace = true
 edition.workspace = true
 
+[features]
+std = ["stwo-cairo-adapter/std", "stwo/std", "stwo-constraint-framework/std"]
+
 [dependencies]
 itertools.workspace = true
 clap.workspace = true


### PR DESCRIPTION
When using `cairo-air` as a dependency from an external application, there are multiple building issues caused by default no_std (in adapter crate, and also in the cairo-vm dependency).
This PR fixes std propagation just for the `cairo-air` crate, the issue might persist for other crates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1153)
<!-- Reviewable:end -->
