### PR TITLE
Continuous verifier benchmarking

### DIFF
--- a/.github/workflows/cairo-ci.yaml
+++ b/.github/workflows/cairo-ci.yaml
@@ -8,6 +8,9 @@ on:
     types:
       - checks_requested
 
+permissions:
+  pull-requests: write
+
 jobs:
   scarb-test:
     runs-on: stwo-cairo-avx-l
@@ -25,17 +28,38 @@ jobs:
       - run: scarb test --features=poseidon252_verifier --package stwo_cairo_air
       - run: scarb test --features=poseidon252_verifier --package stwo_cairo_verifier
       - run: scarb test --features=poseidon252_verifier --package stwo_verifier_utils
-      - run: scarb --profile proving execute --package stwo_cairo_verifier  --features poseidon252_verifier --print-resource-usage --output none --arguments-file ../stwo_cairo_prover/test_data/test_prove_verify_ret_opcode/proof.json
       - run: scarb test --features=qm31_opcode --package stwo_verifier_core
       - run: scarb test --features=qm31_opcode --package stwo_cairo_air
       - run: scarb test --features=qm31_opcode --package stwo_cairo_verifier
       - run: scarb test --features=qm31_opcode --package stwo_verifier_utils
-      - run: scarb --profile proving execute --package stwo_cairo_verifier  --features qm31_opcode --print-resource-usage --output none --arguments-file ../stwo_cairo_prover/test_data/test_prove_verify_all_opcode_components/proof.json
       - run: scarb test --features=qm31_opcode --features=blake_outputs_packing  --package stwo_verifier_core
       - run: scarb test --features=qm31_opcode --features=blake_outputs_packing --package stwo_cairo_air
       - run: scarb test --features=qm31_opcode --features=blake_outputs_packing --package stwo_cairo_verifier
       - run: scarb test --features=qm31_opcode --features=blake_outputs_packing --package stwo_verifier_utils
-      - run: scarb --profile proving execute --package stwo_cairo_verifier  --features qm31_opcode --features blake_outputs_packing --print-resource-usage --output none --arguments-file ../stwo_cairo_prover/test_data/test_prove_verify_all_opcode_components/proof.json
+      - name: Run benchmark
+        run: ./scripts/bench_ci.sh target/bench_output.json
+      - name: Download previous benchmark data
+        uses: actions/cache/restore@v4
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+      - name: Process benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Verifier benchmark
+          tool: 'customSmallerIsBetter'
+          output-file-path: stwo_cairo_verifier/target/bench_output.json
+          external-data-json-path: ./cache/benchmark-data.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-always: true
+          summary-always: true
+          save-data-file: true
+      - name: Store updated benchmark data
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/cache/save@v4
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
   run-tests:
     runs-on: stwo-cairo-avx-l
     defaults:

--- a/stwo_cairo_verifier/scripts/bench_ci.sh
+++ b/stwo_cairo_verifier/scripts/bench_ci.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+# Check if output file is provided as first argument
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <output_file>"
+    echo "Example: $0 target/bench_output.json"
+    exit 1
+fi
+
+OUTPUT_FILE="$1"
+
+# Define variables
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_DATA_DIR="$PROJECT_ROOT/stwo_cairo_prover/test_data"
+TARGET_DIR="$PROJECT_ROOT/stwo_cairo_verifier/target"
+SCARB_PROFILE="proving"
+
+# Function to extract bytecode size from executable JSON
+extract_bytecode_size() {
+    jq '.program.bytecode | length' "$TARGET_DIR/$SCARB_PROFILE/stwo_cairo_verifier.executable.json"
+}
+
+echo "Running benchmark without qm31_opcode feature"
+scarb --profile $SCARB_PROFILE execute \
+    --package stwo_cairo_verifier \
+    --features poseidon252_verifier \
+    --arguments-file "$TEST_DATA_DIR/test_prove_verify_ret_opcode/proof.json" \
+    --print-resource-usage \
+    --output none \
+    2>&1 | tee $TARGET_DIR/bench_output_0.txt
+if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    echo "Error: scarb execute failed for poseidon252_verifier benchmark"
+    exit 1
+fi
+
+bytecode_size_0=$(extract_bytecode_size)
+
+echo "Running benchmark with qm31_opcode feature"
+scarb --profile $SCARB_PROFILE execute \
+    --package stwo_cairo_verifier \
+    --features qm31_opcode \
+    --arguments-file "$TEST_DATA_DIR/test_prove_verify_all_opcode_components/proof.json" \
+    --print-resource-usage \
+    --output none \
+    2>&1 | tee $TARGET_DIR/bench_output_1.txt
+if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    echo "Error: scarb execute failed for qm31_opcode benchmark"
+    exit 1
+fi
+
+bytecode_size_1=$(extract_bytecode_size)
+
+echo "Running benchmark with qm31_opcode and outputs_packing features"
+scarb --profile $SCARB_PROFILE execute \
+    --package stwo_cairo_verifier  \
+    --features qm31_opcode \
+    --features blake_outputs_packing \
+    --print-resource-usage \
+    --output none \
+    --arguments-file "$TEST_DATA_DIR/test_prove_verify_all_opcode_components/proof.json" \
+    2>&1 | tee $TARGET_DIR/bench_output_2.txt
+if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    echo "Error: scarb execute failed for qm31_opcode + blake_outputs_packing benchmark"
+    exit 1
+fi
+
+bytecode_size_2=$(extract_bytecode_size)
+
+# Function to extract steps from scarb execute output
+extract_steps() {
+    grep -o "steps: [0-9,]*" "$1" | sed 's/steps: //' | tr -d ','
+}
+
+# Extract steps from output files
+cairo_steps_0=$(extract_steps "$TARGET_DIR/bench_output_0.txt")
+cairo_steps_1=$(extract_steps "$TARGET_DIR/bench_output_1.txt")
+cairo_steps_2=$(extract_steps "$TARGET_DIR/bench_output_2.txt")
+
+# Generate JSON output to file
+cat << EOF > "$OUTPUT_FILE"
+[
+    {
+        "name": "Poseidon252 verifier: Cairo steps",
+        "unit": "",
+        "value": $cairo_steps_0
+    },
+    {
+        "name": "Poseidon252 verifier: bytecode size",
+        "unit": "",
+        "value": $bytecode_size_0
+    },
+    {
+        "name": "QM31 opcode: Cairo steps",
+        "unit": "",
+        "value": $cairo_steps_1
+    },
+    {
+        "name": "QM31 opcode: bytecode size",
+        "unit": "",
+        "value": $bytecode_size_1
+    },
+    {
+        "name": "QM31 opcode + Blake outputs packing: Cairo steps",
+        "unit": "",
+        "value": $cairo_steps_2
+    },
+    {
+        "name": "QM31 opcode + Blake outputs packing: bytecode size",
+        "unit": "",
+        "value": $bytecode_size_2
+    }
+]
+EOF
+
+# Print the contents of the output file
+cat "$OUTPUT_FILE"


### PR DESCRIPTION
# Add benchmarking to Cairo CI workflow

Added benchmarking capabilities to the Cairo CI workflow to track performance metrics over time.

## Changes

- Added pull-requests write permission to the GitHub workflow
- Created a new `bench_ci.sh` script that:
  - Runs the Cairo verifier with different feature configurations
  - Extracts step counts and bytecode sizes
  - Formats the results as JSON for the benchmark action
- Modified the CI workflow to:
  - Run the benchmarking script
  - Download previous benchmark data from cache
  - Process and display benchmark results using benchmark-action
  - Store updated benchmark data when running on main branch
- Removed direct scarb execute commands in favor of the benchmarking script
- Added benchmark metrics for:
  - Poseidon252 verifier (steps and bytecode size)
  - QM31 opcode (steps and bytecode size)
  - QM31 opcode with outputs packing (steps and bytecode size)

This change enables tracking performance metrics over time, allowing us to identify performance regressions and measure the impact of code changes on the Cairo verifier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1221)
<!-- Reviewable:end -->
