### PR TITLE
Optimize bit_reverse_index

### DIFF
--- a/stwo_cairo_verifier/crates/verifier_core/src/utils.cairo
+++ b/stwo_cairo_verifier/crates/verifier_core/src/utils.cairo
@@ -159,17 +159,17 @@ pub fn pack4(cur: felt252, values: [M31; 4]) -> felt252 {
         + x3.into()
 }
 
-pub fn bit_reverse_index(mut index: usize, mut bits: u32) -> usize {
-    assert!(bits <= BitSize::<usize>::bits());
+/// Takes the first `n_bits` bits of the given index, reverses them, and returns the result.
+pub fn bit_reverse_index(mut index: usize, mut n_bits: u32) -> usize {
+    assert!(n_bits <= BitSize::<usize>::bits());
 
-    let NZ2: NonZero<usize> = 2;
-
+    let mut n_bits: felt252 = n_bits.into();
     let mut result = 0;
-    while bits > 0 {
-        let (next_index, bit) = DivRem::div_rem(index, NZ2);
-        result = (result * 2) | bit;
+    while n_bits != 0 {
+        let (next_index, bit) = DivRem::div_rem(index, 2);
+        result = result * 2 + bit;
         index = next_index;
-        bits -= 1;
+        n_bits -= 1;
     }
     result
 }


### PR DESCRIPTION
Resources:
steps: 20,691,184 -> 20,350,882 (-1.6%)
max memory address: 19,536,867 -> 19,059,579 (-2.4%)
range_check_builtin: 1,664,557 -> 1,660,576
bitwise_builtin: 62,169 -> 72 (!)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1225)
<!-- Reviewable:end -->
