### PR TITLE
cairo-prove: decode json proof from buffer

### DIFF
--- a/cairo-prove/README.md
+++ b/cairo-prove/README.md
@@ -22,6 +22,12 @@ cd stwo-cairo/cairo-prove
 sudo cp target/release/cairo-prove /usr/local/bin/
 ```
 
+Alternatively use cargo install:
+
+```bash
+cargo install --git https://github.com/starkware-libs/stwo-cairo cairo-prove
+```
+
 ## Usage
 
 ### Compiling a project.

--- a/cairo-prove/src/main.rs
+++ b/cairo-prove/src/main.rs
@@ -61,8 +61,8 @@ fn handle_prove(target: &Path, proof: &Path, proof_format: ProofFormat, args: Pr
 
 fn handle_verify(proof: &Path, with_pedersen: bool) {
     info!("Verifying proof from: {:?}", proof);
-    let cairo_proof =
-        serde_json::from_reader(std::fs::File::open(proof.to_str().unwrap()).unwrap()).unwrap();
+    let proof_str = std::fs::read_to_string(proof.to_str().unwrap()).expect("Failed to read proof");
+    let cairo_proof = serde_json::from_str(&proof_str).expect("Failed to parse proof");
     let preprocessed_trace = match with_pedersen {
         true => PreProcessedTraceVariant::Canonical,
         false => PreProcessedTraceVariant::CanonicalWithoutPedersen,

--- a/cairo-prove/src/prove.rs
+++ b/cairo-prove/src/prove.rs
@@ -5,7 +5,7 @@ use cairo_vm::vm::runners::cairo_runner::CairoRunner;
 use log::{debug, info};
 use stwo_cairo_adapter::builtins::MemorySegmentAddresses;
 use stwo_cairo_adapter::memory::{MemoryBuilder, MemoryConfig, MemoryEntry};
-use stwo_cairo_adapter::vm_import::{adapt_to_stwo_input, RelocatedTraceEntry};
+use stwo_cairo_adapter::vm_import::{RelocatedTraceEntry, adapt_to_stwo_input};
 use stwo_cairo_adapter::{ProverInput, PublicSegmentContext};
 use stwo_cairo_prover::stwo_prover::core::pcs::PcsConfig;
 use stwo_cairo_prover::stwo_prover::core::vcs::blake2_merkle::{


### PR DESCRIPTION
Decoding through an unbuffered reader takes more than 10 seconds which affects the benchmarks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1298)
<!-- Reviewable:end -->
