### PR TITLE
Use bincode + bzip2 to compress cairo proof

### DIFF
--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -437,6 +437,15 @@ dependencies = [
 
 [[package]]
 name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
@@ -589,10 +598,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cairo-air"
 version = "0.1.1"
 dependencies = [
+ "bincode 1.3.3",
+ "bzip2",
  "clap",
+ "dev-utils",
  "itertools 0.12.1",
  "log",
  "num-traits",
@@ -610,6 +642,7 @@ dependencies = [
  "stwo-cairo-common",
  "stwo-cairo-serialize",
  "stwo-constraint-framework",
+ "tempfile",
  "thiserror",
  "tracing",
 ]
@@ -682,7 +715,7 @@ name = "cairo-lang-defs"
 version = "2.12.0"
 source = "git+https://github.com/starkware-libs/cairo.git?rev=86eb25173f9d8700adbd2770406d715fbf1bb9f8#86eb25173f9d8700adbd2770406d715fbf1bb9f8"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -784,7 +817,7 @@ version = "2.12.0"
 source = "git+https://github.com/starkware-libs/cairo.git?rev=86eb25173f9d8700adbd2770406d715fbf1bb9f8#86eb25173f9d8700adbd2770406d715fbf1bb9f8"
 dependencies = [
  "assert_matches",
- "bincode",
+ "bincode 2.0.1",
  "cairo-lang-debug",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -1182,7 +1215,7 @@ version = "2.0.1"
 source = "git+https://github.com/lambdaclass/cairo-vm?rev=e2c6c91c73cd0bc351721f302390fcc0965c6224#e2c6c91c73cd0bc351721f302390fcc0965c6224"
 dependencies = [
  "anyhow",
- "bincode",
+ "bincode 2.0.1",
  "bitvec",
  "clap",
  "generic-array",
@@ -2413,6 +2446,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,7 +3394,7 @@ dependencies = [
 name = "stwo-cairo-adapter"
 version = "0.1.0"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "bytemuck",
  "cairo-lang-casm 2.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-vm",

--- a/stwo_cairo_prover/Cargo.toml
+++ b/stwo_cairo_prover/Cargo.toml
@@ -17,6 +17,8 @@ version = "0.1.1"
 edition = "2021"
 
 [workspace.dependencies]
+bincode = "1.3"
+bzip2 = "0.4"
 bytemuck = { version = "1.20.0", features = ["derive"] }
 cairo-lang-casm = "2.7.1"
 # TODO(yuval): Use an official version, not a specific commit.
@@ -64,6 +66,7 @@ tracing-subscriber = "0.3.18"
 serde_arrays = "0.1.0"
 rayon = "1.10.0"
 indoc = "2.0.6"
+tempfile = "3.8.1"
 
 [profile.bench]
 codegen-units = 1

--- a/stwo_cairo_prover/crates/cairo-air/Cargo.toml
+++ b/stwo_cairo_prover/crates/cairo-air/Cargo.toml
@@ -8,6 +8,8 @@ default = ["std"]
 std = ["stwo-cairo-adapter/std", "stwo/std", "stwo-constraint-framework/std"]
 
 [dependencies]
+bincode.workspace = true
+bzip2.workspace = true
 itertools.workspace = true
 clap.workspace = true
 sonic-rs.workspace = true
@@ -31,3 +33,5 @@ tracing.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
+tempfile.workspace = true
+dev-utils.workspace = true

--- a/stwo_cairo_prover/crates/cairo-air/src/utils/tests.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/utils/tests.rs
@@ -1,4 +1,11 @@
-use crate::utils::{construct_f252, encode_and_hash_memory_section, encode_felt_in_limbs};
+use dev_utils::utils::get_proof_file_path;
+use stwo::core::vcs::blake2_merkle::Blake2sMerkleHasher;
+use tempfile::NamedTempFile;
+
+use crate::utils::{
+    construct_f252, deserialize_proof_from_file, encode_and_hash_memory_section,
+    encode_felt_in_limbs, serialize_proof_to_file, ProofFormat,
+};
 
 #[test]
 fn test_encode_felt_in_limbs() {
@@ -55,4 +62,60 @@ fn test_construct_f252() {
     )
     .unwrap();
     assert_eq!(construct_f252(&limbs), expected);
+}
+
+#[cfg(feature = "slow-tests")]
+#[test]
+fn test_serialize_and_deserialize_proof() {
+    let proof_path = get_proof_file_path("test_prove_verify_all_opcode_components");
+    let mut proof =
+        deserialize_proof_from_file::<Blake2sMerkleHasher>(&proof_path, ProofFormat::CairoSerde)
+            .expect("Failed to deserialize proof (CairoSerde)");
+
+    let temp_json_file = NamedTempFile::new().expect("Failed to create temp file");
+    serialize_proof_to_file::<Blake2sMerkleHasher>(
+        &proof,
+        temp_json_file.path(),
+        ProofFormat::Json,
+    )
+    .expect("Failed to serialize proof (Json)");
+
+    proof = deserialize_proof_from_file::<Blake2sMerkleHasher>(
+        &temp_json_file.path(),
+        ProofFormat::Json,
+    )
+    .expect("Failed to deserialize proof (Json)");
+
+    let temp_binary_file = NamedTempFile::new().expect("Failed to create temp file");
+    serialize_proof_to_file::<Blake2sMerkleHasher>(
+        &proof,
+        temp_binary_file.path(),
+        ProofFormat::Binary,
+    )
+    .expect("Failed to serialize proof (Binary)");
+
+    proof = deserialize_proof_from_file::<Blake2sMerkleHasher>(
+        &temp_binary_file.path(),
+        ProofFormat::Binary,
+    )
+    .expect("Failed to deserialize proof (Binary)");
+
+    let temp_serde_file = NamedTempFile::new().expect("Failed to create temp file");
+    serialize_proof_to_file::<Blake2sMerkleHasher>(
+        &proof,
+        temp_serde_file.path(),
+        ProofFormat::CairoSerde,
+    )
+    .expect("Failed to serialize proof (CairoSerde)");
+
+    // Verify the final serialized proof matches the original by comparing JSON strings
+    let final_json =
+        std::fs::read_to_string(temp_serde_file.path()).expect("Failed to read final proof file");
+    let original_json =
+        std::fs::read_to_string(&proof_path).expect("Failed to read original proof file");
+
+    assert_eq!(
+        final_json, original_json,
+        "Final serialized proof should match the original proof"
+    );
 }

--- a/stwo_cairo_prover/crates/dev_utils/src/bin/prove_from_compiled_program.rs
+++ b/stwo_cairo_prover/crates/dev_utils/src/bin/prove_from_compiled_program.rs
@@ -47,6 +47,7 @@ struct Args {
     /// The format of the proof output.
     /// - json: Standard JSON format (default)
     /// - cairo_serde: Array of field elements serialized as hex strings, ex. `["0x1", "0x2"]`
+    /// - binary: Binary format, compressed
     #[arg(long, value_enum, default_value_t = ProofFormat::Json)]
     proof_format: ProofFormat,
     /// Verify the generated proof.

--- a/stwo_cairo_prover/crates/dev_utils/src/utils.rs
+++ b/stwo_cairo_prover/crates/dev_utils/src/utils.rs
@@ -65,7 +65,7 @@ where
 {
     let proof = prove_cairo::<MC>(input, pcs_config, preprocessed_trace)?;
 
-    serialize_proof_to_file::<MC>(&proof, proof_path, proof_format)?;
+    serialize_proof_to_file::<MC::H>(&proof, &proof_path, proof_format)?;
 
     if verify {
         verify_cairo::<MC>(proof, preprocessed_trace)?;


### PR DESCRIPTION
### TL;DR

Added binary proof format with compression to reduce proof size.  
Will later cherry-pick to the branch cairo-prove is locked on.

### What changed?

- Added a new `Binary` option to the `ProofFormat` enum that serializes proofs using bincode and compresses them with bzip2
- Implemented serialization and deserialization functions for the binary format
- Added dependencies on `bincode` 1.3.3 and `bzip2` 0.4.4 to support the new format
- Refactored proof serialization code in dev_utils

### How to test?

Run the test suite which includes a new test for serializing and deserializing proofs in different formats

### Why make this change?

The binary format with compression significantly reduces proof size compared to the text-based formats (JSON and CairoSerde).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1300)
<!-- Reviewable:end -->
