### PR TITLE
Convert between all proof formats

### DIFF
--- a/stwo_cairo_prover/crates/cairo-air/Cargo.toml
+++ b/stwo_cairo_prover/crates/cairo-air/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [features]
 default = ["std"]
 std = ["stwo-cairo-adapter/std", "stwo/std", "stwo-constraint-framework/std"]
+slow-tests = []
 
 [dependencies]
 bincode.workspace = true

--- a/stwo_cairo_prover/crates/cairo-air/src/utils.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/utils.rs
@@ -63,8 +63,7 @@ where
             proof_file.write_all(sonic_rs::to_string_pretty(&hex_strings)?.as_bytes())?;
         }
         ProofFormat::Binary => {
-            let serialized_bytes = bincode::serialize(proof)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            let serialized_bytes = bincode::serialize(proof).map_err(std::io::Error::other)?;
 
             let mut bz_encoder = BzEncoder::new(proof_file, Compression::best());
             bz_encoder.write_all(&serialized_bytes)?;
@@ -87,13 +86,12 @@ where
     match proof_format {
         ProofFormat::Json => {
             let proof_str = std::fs::read_to_string(proof_path)?;
-            sonic_rs::from_str(&proof_str)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+            sonic_rs::from_str(&proof_str).map_err(std::io::Error::other)
         }
         ProofFormat::CairoSerde => {
             let proof_str = std::fs::read_to_string(proof_path)?;
-            let felts: Vec<starknet_ff::FieldElement> = sonic_rs::from_str(&proof_str)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            let felts: Vec<starknet_ff::FieldElement> =
+                sonic_rs::from_str(&proof_str).map_err(std::io::Error::other)?;
             Ok(CairoDeserialize::deserialize(&mut felts.iter()))
         }
         ProofFormat::Binary => {
@@ -101,8 +99,7 @@ where
             let mut proof_bytes = Vec::new();
             let mut bz_decoder = BzDecoder::new(proof_file);
             bz_decoder.read_to_end(&mut proof_bytes)?;
-            bincode::deserialize(&proof_bytes)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+            bincode::deserialize(&proof_bytes).map_err(std::io::Error::other)
         }
     }
 }

--- a/stwo_cairo_prover/crates/cairo-air/src/utils/tests.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/utils/tests.rs
@@ -1,11 +1,12 @@
-use dev_utils::utils::get_proof_file_path;
-use stwo::core::vcs::blake2_merkle::Blake2sMerkleHasher;
-use tempfile::NamedTempFile;
-
-use crate::utils::{
-    construct_f252, deserialize_proof_from_file, encode_and_hash_memory_section,
-    encode_felt_in_limbs, serialize_proof_to_file, ProofFormat,
+#[cfg(feature = "slow-tests")]
+use {
+    crate::utils::{deserialize_proof_from_file, serialize_proof_to_file, ProofFormat},
+    dev_utils::utils::get_proof_file_path,
+    stwo::core::vcs::blake2_merkle::Blake2sMerkleHasher,
+    tempfile::NamedTempFile,
 };
+
+use crate::utils::{construct_f252, encode_and_hash_memory_section, encode_felt_in_limbs};
 
 #[test]
 fn test_encode_felt_in_limbs() {
@@ -81,7 +82,7 @@ fn test_serialize_and_deserialize_proof() {
     .expect("Failed to serialize proof (Json)");
 
     proof = deserialize_proof_from_file::<Blake2sMerkleHasher>(
-        &temp_json_file.path(),
+        temp_json_file.path(),
         ProofFormat::Json,
     )
     .expect("Failed to deserialize proof (Json)");
@@ -95,7 +96,7 @@ fn test_serialize_and_deserialize_proof() {
     .expect("Failed to serialize proof (Binary)");
 
     proof = deserialize_proof_from_file::<Blake2sMerkleHasher>(
-        &temp_binary_file.path(),
+        temp_binary_file.path(),
         ProofFormat::Binary,
     )
     .expect("Failed to deserialize proof (Binary)");


### PR DESCRIPTION
### TL;DR

Enhanced the proof format conversion utility to support configurable input and output formats.

### What changed?

- Added two new command-line arguments to the `convert_proof_format` utility:
  - `--input-format`: Specifies the format of the input proof file (defaults to "cairo_serde")
  - `--output-format`: Specifies the format of the output proof file (defaults to "json")
- Updated the `convert_proof` function to accept these format parameters
- Modified the success message to be format-agnostic
- Enhanced the logging to display both input and output formats

### How to test?

Run the utility with the new format options:
```bash
cargo run --bin convert_proof_format -- --input proof.bin --output proof.json --input-format cairo_serde --output-format json --hash blake2s
```

Or use the default formats:
```bash
cargo run --bin convert_proof_format -- --input proof.bin --output proof.json --hash blake2s
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1342)
<!-- Reviewable:end -->
