### PR TITLE
chore: fix incorrect package name

### DIFF
--- a/stwo_cairo_prover/scripts/fetch_large_files.sh
+++ b/stwo_cairo_prover/scripts/fetch_large_files.sh
@@ -11,7 +11,7 @@ fi
 
 # Check if jq is installed
 if ! command -v jq &> /dev/null; then
-    echo "Error: 'jq' is not installed. Run: sudo apt-get install js."
+    echo "Error: 'jq' is not installed. Run: sudo apt-get install jq."
     exit 1
 fi
 


### PR DESCRIPTION
the error message now correctly instructs users to install `jq` instead of the incorrect `js` package name. This was on line 14 of the `stwo_cairo_prover/scripts/fetch_large_files.sh` file.
