### PR TITLE
Refactor json backends, use sonic-rs from workspace

### DIFF
--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -603,7 +603,6 @@ name = "cairo-air"
 version = "0.1.1"
 dependencies = [
  "bincode 1.3.3",
- "bzip2",
  "clap",
  "dev-utils",
  "itertools 0.12.1",
@@ -614,7 +613,6 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "sonic-rs",
  "starknet-ff",
  "starknet-types-core",
  "stwo",

--- a/stwo_cairo_prover/crates/adapter/Cargo.toml
+++ b/stwo_cairo_prover/crates/adapter/Cargo.toml
@@ -3,7 +3,6 @@ name = "stwo-cairo-adapter"
 version = "0.1.0"
 edition = "2021"
 
-
 [features]
 default = []
 slow-tests = []
@@ -21,7 +20,6 @@ serde_json.workspace = true
 stwo-cairo-common.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
-sonic-rs = { version = "0.3.17", optional = true }
 stwo.workspace = true
 memmap2 = "0.9.5"
 bincode = { version = "2.0.1", features = ["serde"] }
@@ -33,6 +31,9 @@ cairo-lang-executable = { git = "https://github.com/starkware-libs/cairo.git", r
 cairo-lang-runner = { git = "https://github.com/starkware-libs/cairo.git", rev = "86eb25173f9d8700adbd2770406d715fbf1bb9f8" }
 cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "86eb25173f9d8700adbd2770406d715fbf1bb9f8" }
 anyhow.workspace = true
+
+[target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
+sonic-rs = { workspace = true, optional = true }
 
 [dev-dependencies]
 cairo-lang-casm.workspace = true

--- a/stwo_cairo_prover/crates/cairo-air/Cargo.toml
+++ b/stwo_cairo_prover/crates/cairo-air/Cargo.toml
@@ -10,10 +10,8 @@ slow-tests = []
 
 [dependencies]
 bincode.workspace = true
-bzip2.workspace = true
 itertools.workspace = true
 clap.workspace = true
-sonic-rs.workspace = true
 log.workspace = true
 num-traits.workspace = true
 paste.workspace = true

--- a/stwo_cairo_prover/crates/prover/Cargo.toml
+++ b/stwo_cairo_prover/crates/prover/Cargo.toml
@@ -46,4 +46,3 @@ tempfile = "3.19.1"
 test-log = { version = "0.2.17", features = ["trace"] }
 tracing-subscriber.workspace = true
 rand.workspace = true
-sonic-rs = { version = "0.3.17" }


### PR DESCRIPTION
Allows to build for wasm32 target with std feature enabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1405)
<!-- Reviewable:end -->
