### PR TITLE
Build prover and cairo-air for wasm32/64

### DIFF
--- a/.github/workflows/cairo-ci.yaml
+++ b/.github/workflows/cairo-ci.yaml
@@ -120,6 +120,37 @@ jobs:
           workspaces: cairo-prove
       - run: ./scripts/test_flow.sh
 
+  cairo-prover-wasm:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./stwo_cairo_prover
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-07-14
+          targets: x86_64-unknown-linux-gnu
+          components: rust-src
+      - uses: Swatinem/rust-cache@v2
+      - name: Build stwo_cairo_prover for wasm64
+        run: RUSTFLAGS='--cfg getrandom_backend="custom"' cargo check --target wasm64-unknown-unknown -Z build-std=std,panic_abort --package stwo_cairo_prover --release 
+
+  cairo-air-wasm:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./stwo_cairo_prover
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-07-14
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: Build cairo-air for wasm32
+        run: cargo check --package cairo-air --no-default-features --target wasm32-unknown-unknown --release
+
   format:
     runs-on: ubuntu-latest
     defaults:

--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -207,7 +207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -327,7 +327,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -395,7 +395,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -462,9 +462,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitvec"
@@ -557,7 +557,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -574,12 +574,12 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
 dependencies = [
  "bzip2-sys",
- "libc",
+ "libbz2-rs-sys",
 ]
 
 [[package]]
@@ -856,7 +856,7 @@ checksum = "3c67a1d41548007ea99a1d3f22f39b51a0ad4e51aa6b3495419ee18bc6e732d4"
 dependencies = [
  "cairo-lang-debug",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1164,7 +1164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40373deba5872449e71932afa9273faa3e44ab02767d5cf0ef49eb53aeed548"
 dependencies = [
  "hashbrown 0.15.5",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "itertools 0.14.0",
  "num-bigint",
  "num-traits",
@@ -1229,9 +1229,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
+checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1239,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.49"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
+checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1258,7 +1258,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1499,7 +1499,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1511,7 +1511,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1546,7 +1546,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1708,7 +1708,7 @@ checksum = "43eaff6bbc0b3a878361aced5ec6a2818ee7c541c5b33b5880dfa9a86c23e9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1741,16 +1741,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "globset"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+checksum = "eab69130804d941f8075cfd713bf8848a2c3b3f201a9457a11e6f87e1ab62305"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1834,9 +1836,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "ignore"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+checksum = "81776e6f9464432afcc28d03e52eb101c93b6f0566f52aef2427663e700f0403"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1865,7 +1867,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1887,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
@@ -2044,6 +2046,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libbz2-rs-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864a00c8d019e36216b69c2c4ce50b83b7bd966add3cf5ba554ec44f8bebcf5"
+
+[[package]]
 name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,7 +2170,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2315,7 +2323,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2370,7 +2378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
 ]
 
 [[package]]
@@ -2502,7 +2510,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2655,7 +2663,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2717,7 +2725,7 @@ checksum = "35a640b26f007713818e9a9b65d34da1cf58538207b052916a83d80e43f3ffa4"
 dependencies = [
  "bytes",
  "hashbrown 0.15.5",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -2735,7 +2743,7 @@ checksum = "bd83f5f173ff41e00337d97f6572e416d022ef8a19f371817259ae960324c482"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2788,7 +2796,7 @@ version = "0.17.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719825638c59fd26a55412a24561c7c5bcf54364c88b9a7a04ba08a6eafaba8d"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "lock_api",
  "oorandom",
  "parking_lot",
@@ -2808,7 +2816,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2907,7 +2915,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2980,7 +2988,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2991,7 +2999,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3195,7 +3203,7 @@ checksum = "bbc159a1934c7be9761c237333a57febe060ace2bc9e3b337a59a37af206d19f"
 dependencies = [
  "starknet-curve 0.4.2",
  "starknet-ff",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3290,7 +3298,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "itertools 0.12.1",
  "num-traits",
  "rand 0.8.5",
@@ -3324,7 +3332,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3348,7 +3356,6 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "sonic-rs",
  "stwo",
  "stwo-cairo-common",
  "stwo_cairo_utils",
@@ -3390,7 +3397,7 @@ name = "stwo-cairo-serialize-derive"
 version = "0.1.0"
 dependencies = [
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3416,6 +3423,8 @@ dependencies = [
  "cairo-air",
  "dashmap",
  "dev-utils",
+ "getrandom 0.2.16",
+ "getrandom 0.3.4",
  "hex",
  "itertools 0.12.1",
  "num-traits",
@@ -3481,9 +3490,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3536,7 +3545,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3547,7 +3556,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "test-case-core",
 ]
 
@@ -3570,7 +3579,7 @@ checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3590,7 +3599,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3653,7 +3662,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -3667,7 +3676,7 @@ version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.12.0",
  "toml_datetime 0.7.3",
  "toml_parser",
  "winnow",
@@ -3707,7 +3716,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3792,7 +3801,7 @@ checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3830,9 +3839,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3934,7 +3943,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -3956,7 +3965,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4209,7 +4218,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4229,7 +4238,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]

--- a/stwo_cairo_prover/Cargo.toml
+++ b/stwo_cairo_prover/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 
 [workspace.dependencies]
 bincode = "1.3"
-bzip2 = "0.4"
+bzip2 = { version = "0.5.0", default-features = false, features = ["libbz2-rs-sys"] }
 bytemuck = { version = "1.20.0", features = ["derive"] }
 cairo-lang-casm = { version = "2.12.4-dev.1" }
 cairo-lang-runner = { version = "2.12.4-dev.1" }

--- a/stwo_cairo_prover/crates/adapter/Cargo.toml
+++ b/stwo_cairo_prover/crates/adapter/Cargo.toml
@@ -20,7 +20,6 @@ serde_json.workspace = true
 stwo-cairo-common.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
-sonic-rs = { version = "0.3.17", optional = true }
 stwo.workspace = true
 memmap2 = "0.9.5"
 bincode = { version = "2.0.1", features = ["serde"] }

--- a/stwo_cairo_prover/crates/adapter/src/opcodes.rs
+++ b/stwo_cairo_prover/crates/adapter/src/opcodes.rs
@@ -701,19 +701,11 @@ fn u256_from_le_array(arr: [u32; 8]) -> U256 {
 // 2^29 - 1
 const SMALL_ADD_POSITIVE_UPPER_BOUND: U256 = U256::from_u32(2_u32.pow(29) - 1);
 // P - 2^29 - 1
-const SMALL_ADD_NEGATIVE_LOWER_BOUND: U256 = U256::from_words([
-    0xFFFFFFFFE0000000,
-    0xFFFFFFFFFFFFFFFF,
-    0xFFFFFFFFFFFFFFFF,
-    0x0800000000000010,
-]);
+const SMALL_ADD_NEGATIVE_LOWER_BOUND: U256 =
+    U256::from_be_hex("0800000000000010FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE0000000");
 // P - 1
-const SMALL_ADD_NEGATIVE_UPPER_BOUND: U256 = U256::from_words([
-    0x000000000000000,
-    0x000000000000000,
-    0x000000000000000,
-    0x0800000000000011,
-]);
+const SMALL_ADD_NEGATIVE_UPPER_BOUND: U256 =
+    U256::from_be_hex("0800000000000011000000000000000000000000000000000000000000000000");
 
 // Returns 'true' if all the operands modulo P are within the range of [-2^29 - 1, 2^29 - 1].
 fn is_small_add(dst: MemoryValue, op0: MemoryValue, op_1: MemoryValue) -> bool {

--- a/stwo_cairo_prover/crates/cairo-air/Cargo.toml
+++ b/stwo_cairo_prover/crates/cairo-air/Cargo.toml
@@ -11,7 +11,6 @@ bincode.workspace = true
 bzip2.workspace = true
 itertools.workspace = true
 clap.workspace = true
-sonic-rs.workspace = true
 log.workspace = true
 num-traits.workspace = true
 paste.workspace = true
@@ -28,6 +27,9 @@ stwo-constraint-framework.workspace = true
 thiserror.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
+
+[target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
+sonic-rs.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/stwo_cairo_prover/crates/prover/Cargo.toml
+++ b/stwo_cairo_prover/crates/prover/Cargo.toml
@@ -25,7 +25,6 @@ stwo-cairo-adapter.workspace = true
 rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-sonic-rs.workspace = true
 anyhow.workspace = true
 starknet-curve.workspace = true
 starknet-ff.workspace = true
@@ -37,6 +36,14 @@ stwo-constraint-framework = { workspace = true, features = ["parallel"] }
 tracing.workspace = true
 dashmap.workspace = true
 
+[target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
+sonic-rs.workspace = true
+
+# Override getrandom feature flags for indirect dependencies.
+[target.'cfg(any(target_arch = "wasm32", target_arch = "wasm64"))'.dependencies]
+getrandom_v2 = { version = "0.2", package = "getrandom", features = ["js"] }
+getrandom_v3 = { version = "0.3", package = "getrandom", features = ["wasm_js"] }
+
 [dev-dependencies]
 dev-utils.workspace = true
 stwo_cairo_utils.workspace = true
@@ -44,4 +51,4 @@ tempfile = "3.19.1"
 test-log = { version = "0.2.17", features = ["trace"] }
 tracing-subscriber.workspace = true
 rand.workspace = true
-sonic-rs = { version = "0.3.17" }
+sonic-rs.workspace = true

--- a/stwo_cairo_prover/crates/prover/src/prover.rs
+++ b/stwo_cairo_prover/crates/prover/src/prover.rs
@@ -8,7 +8,6 @@ use cairo_air::verifier::{verify_cairo, INTERACTION_POW_BITS};
 use cairo_air::{CairoProof, PreProcessedTraceVariant};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
-use sonic_rs::from_str;
 use stwo::core::channel::{Channel, MerkleChannel};
 use stwo::core::fields::qm31::SecureField;
 use stwo::core::fri::FriConfig;
@@ -16,7 +15,6 @@ use stwo::core::pcs::PcsConfig;
 use stwo::core::poly::circle::CanonicCoset;
 use stwo::core::proof_of_work::GrindOps;
 use stwo::core::vcs::blake2_merkle::Blake2sMerkleChannel;
-use stwo::core::vcs::poseidon252_merkle::Poseidon252MerkleChannel;
 use stwo::prover::backend::simd::SimdBackend;
 use stwo::prover::backend::BackendForChannel;
 use stwo::prover::poly::circle::PolyOps;
@@ -26,6 +24,13 @@ use tracing::{event, span, Level};
 
 use crate::witness::cairo::CairoClaimGenerator;
 use crate::witness::utils::witness_trace_cells;
+
+mod json {
+    #[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
+    pub use serde_json::from_str;
+    #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
+    pub use sonic_rs::from_str;
+}
 
 pub(crate) const LOG_MAX_ROWS: u32 = 26;
 
@@ -181,7 +186,7 @@ pub fn create_and_serialize_proof(
     proof_params_json: Option<PathBuf>,
 ) -> Result<()> {
     let proof_params = if let Some(proof_params_json) = proof_params_json {
-        from_str(&read_to_string(&proof_params_json)?)?
+        json::from_str(&read_to_string(&proof_params_json)?)?
     } else {
         // The default prover parameters for prod use (96 bits of security).
         // The formula is `security_bits = pow_bits + log_blowup_factor * n_queries`.
@@ -213,7 +218,13 @@ pub fn create_and_serialize_proof(
                 verify_cairo::<Blake2sMerkleChannel>(proof, proof_params.preprocessed_trace)?;
             }
         }
+        #[cfg(any(target_arch = "wasm32", target_arch = "wasm64"))]
         ChannelHash::Poseidon252 => {
+            unimplemented!("Poseidon252 is not supported for wasm targets");
+        }
+        #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
+        ChannelHash::Poseidon252 => {
+            use stwo::core::vcs::poseidon252_merkle::Poseidon252MerkleChannel;
             let proof = prove_cairo::<Poseidon252MerkleChannel>(input, proof_params)?;
             serialize_proof_to_file(&proof, &proof_path, proof_format)?;
             if verify {

--- a/stwo_cairo_prover/crates/prover/src/witness/utils.rs
+++ b/stwo_cairo_prover/crates/prover/src/witness/utils.rs
@@ -8,7 +8,6 @@ use stwo::core::channel::MerkleChannel;
 use stwo::core::fields::m31::M31;
 use stwo::core::pcs::{TreeSubspan, TreeVec};
 use stwo::core::vcs::blake2_merkle::Blake2sMerkleChannel;
-use stwo::core::vcs::poseidon252_merkle::Poseidon252MerkleChannel;
 use stwo::core::vcs::MerkleHasher;
 use stwo::prover::backend::simd::column::BaseColumn;
 use stwo::prover::backend::simd::conversion::Pack;
@@ -163,20 +162,26 @@ pub fn export_preprocessed_roots() {
 
         println!("log_blowup_factor: {}, blake root: [{}]", i + 1, u32s_hex);
     });
+
     // Poseidon252 roots.
-    get_preprocessed_roots::<Poseidon252MerkleChannel>(
-        max_log_blowup_factor,
-        PreProcessedTraceVariant::CanonicalWithoutPedersen,
-    )
-    .into_iter()
-    .enumerate()
-    .for_each(|(i, root)| {
-        println!(
-            "log_blowup_factor: {}, poseidon root: [{:#010x}]",
-            i + 1,
-            root
-        );
-    });
+    #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
+    {
+        use stwo::core::vcs::poseidon252_merkle::Poseidon252MerkleChannel;
+        // Poseidon252 roots.
+        get_preprocessed_roots::<Poseidon252MerkleChannel>(
+            max_log_blowup_factor,
+            PreProcessedTraceVariant::CanonicalWithoutPedersen,
+        )
+        .into_iter()
+        .enumerate()
+        .for_each(|(i, root)| {
+            println!(
+                "log_blowup_factor: {}, poseidon root: [{:#010x}]",
+                i + 1,
+                root
+            );
+        });
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### TL;DR

Update dependencies and add WASM target support for the Cairo prover.

### What changed?

- Updated several dependencies including `bzip2` (0.4.4 → 0.5.2), `seize`, `term`, `toml_parser`, `toml_writer`, `typetag`, and `winapi-util`
- Added conditional compilation for WASM targets (wasm32/wasm64)
- Modified JSON serialization/deserialization to use `serde_json` for WASM targets and `sonic-rs` for other targets
- Removed direct dependency on `bzip2` from the prover crate and moved it to cairo-air
- Fixed U256 constant definitions in opcodes.rs using `from_be_hex` instead of `from_words`
- Made Poseidon252 hash channel unavailable for WASM targets

### How to test?

```sh
RUSTFLAGS='--cfg getrandom_backend="custom"' cargo build --target wasm64-unknown-unknown -Z build-std=std,panic_abort --package stwo_cairo_prover --release

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1410)
<!-- Reviewable:end -->
