### PR TITLE
fix: rely on hasher type inference in proof serialization

### DIFF
--- a/cairo-prove/src/main.rs
+++ b/cairo-prove/src/main.rs
@@ -52,7 +52,7 @@ fn handle_prove(target: &Path, proof: &Path, proof_format: ProofFormat, args: Pr
     );
     let elapsed = start.elapsed();
 
-    serialize_proof_to_file::<Blake2sMerkleChannel>(&cairo_proof, proof.into(), proof_format)
+    serialize_proof_to_file(&cairo_proof, proof.into(), proof_format)
         .expect("Failed to serialize proof");
 
     info!("Proof saved to: {:?}", proof);


### PR DESCRIPTION
Problem: serialize_proof_to_file was instantiated with Blake2sMerkleChannel, but the function is generic over the Merkle hasher (H: MerkleHasher), not the channel. This mismatch is inconsistent with the function signature and the rest of the codebase, and can cause type errors.
Solution: Removed the explicit generic parameter and let the compiler infer H from &CairoProof<Blake2sMerkleHasher>. This avoids confusion between channel and hasher types and aligns with established usage patterns in the repository.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1429)
<!-- Reviewable:end -->
