### PR TITLE
Remove `group_by_point`

### DIFF
--- a/stwo_cairo_verifier/Scarb.toml
+++ b/stwo_cairo_verifier/Scarb.toml
@@ -10,8 +10,10 @@ members = [
 ]
 
 [workspace.tool.cairo-lint]
-manual_assert = false
+collapsible_if_else = false
 double_parens = false
+ifs_same_cond = false
+manual_assert = false
 
 [cairo]
 enable-gas = false

--- a/stwo_cairo_verifier/crates/verifier_core/src/verifier.cairo
+++ b/stwo_cairo_verifier/crates/verifier_core/src/verifier.cairo
@@ -1,7 +1,10 @@
 use core::num::traits::Pow;
 use crate::channel::{Channel, ChannelTrait};
 use crate::circle::{ChannelGetRandomCirclePointImpl, CirclePoint};
-use crate::fields::qm31::{QM31, QM31Trait, QM31_EXTENSION_DEGREE};
+// TODO(Ilya): Remove this once we bump the compiler version.
+#[allow(unused_imports)]
+use crate::fields::qm31::QM31_EXTENSION_DEGREE;
+use crate::fields::qm31::{QM31, QM31Trait};
 use crate::pcs::PcsConfigTrait;
 use crate::pcs::verifier::{
     CommitmentSchemeProof, CommitmentSchemeVerifier, CommitmentSchemeVerifierImpl,
@@ -79,17 +82,6 @@ pub fn verify<A, +Air<A>, +Drop<A>>(
     // Draw OOD point.
     let ood_point = channel.get_random_point();
 
-    // Get mask sample points relative to OOD point.
-    let mut sample_points = air.mask_points(ood_point);
-
-    // Add the composition polynomial mask points.
-    sample_points
-        .append(
-            ArrayImpl::new_repeated(
-                n: COMPOSITION_SPLIT_FACTOR * QM31_EXTENSION_DEGREE, v: array![ood_point],
-            ),
-        );
-
     let sampled_oods_values = commitment_scheme_proof.sampled_values;
 
     let composition_oods_eval = try_extract_composition_eval(
@@ -109,7 +101,7 @@ pub fn verify<A, +Air<A>, +Drop<A>>(
         VerificationError::OodsNotMatching,
     );
 
-    commitment_scheme.verify_values(sample_points, commitment_scheme_proof, ref channel);
+    commitment_scheme.verify_values(ood_point, commitment_scheme_proof, ref channel);
 }
 
 fn circle_double_x(x: QM31) -> QM31 {


### PR DESCRIPTION
The grouping was move to fri_answers under the assumption that each column is sampled at one of the following sets of points:
 - `[]`
 - `[oods_point]`
 - `[oods_point - g, oods_point]`A column is sampled either at [], [oods_point] or [oods_point - g, oods_point], where g is the trace generator of the relevant column.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1467)
<!-- Reviewable:end -->
