### PR TITLE
fix: use checked_shl in LinePoly::deserialize

### DIFF
--- a/stwo_cairo_prover/crates/cairo-serialize/src/deserialize.rs
+++ b/stwo_cairo_prover/crates/cairo-serialize/src/deserialize.rs
@@ -86,7 +86,9 @@ impl CairoDeserialize for LinePoly {
         let coeffs = Vec::<SecureField>::deserialize(data);
         let log_size: u32 = u32::deserialize(data);
 
-        let expected_len = 1usize << log_size;
+        let expected_len = 1usize
+            .checked_shl(log_size)
+            .expect("Invalid log_size for LinePoly");
         if coeffs.len() != expected_len {
             panic!("Invalid length for LinePoly");
         }


### PR DESCRIPTION
Replaced the unchecked left shift in LinePoly::deserialize (stwo_cairo_prover/crates/cairo-serialize/src/deserialize.rs) with checked_shl to prevent a runtime shift panic when log_size is oversized. The serializer guarantees valid log_size for well-formed inputs, but deserialization can receive malformed or adversarial data; this change keeps the existing panic-on-invalid policy while making the failure deterministic and explicit for invalid log_size without invoking an undefined shift.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1492)
<!-- Reviewable:end -->
