### PR TITLE
fix(adapter): derive PublicSegmentContext from program builtins

### DIFF
--- a/stwo_cairo_prover/crates/adapter/src/adapter.rs
+++ b/stwo_cairo_prover/crates/adapter/src/adapter.rs
@@ -41,8 +41,8 @@ pub fn adapt(runner: &CairoRunner) -> Result<ProverInput> {
     // TODO(spapini): Add output builtin to public memory.
     let (memory, inst_cache) = memory.build();
 
-    // TODO(Ohad): take this from the input.
-    let public_segment_context = PublicSegmentContext::bootloader_context();
+    let public_segment_context =
+        PublicSegmentContext::new(runner.get_program_builtins());
 
     Ok(ProverInput {
         state_transitions,


### PR DESCRIPTION
## Summary

`adapt()` hardcodes `PublicSegmentContext::bootloader_context()` (all 11 builtins present), which causes incorrect segment range extraction for programs that declare a subset of builtins.

This resolves the `TODO(Ohad): take this from the input` on the replaced line.

## Problem

`extract_public_segments` reads `n_public_segments` pointer pairs from the AP region, where `n` is determined by `PublicSegmentContext`. With `bootloader_context()`, `n = 11` regardless of the program's actual builtins.

For a program declaring fewer builtins (e.g. 6: `output, range_check, bitwise, range_check96, add_mod, mul_mod`), only 6 pairs exist in the AP region. Reading 11 pairs causes:

1. **Out-of-bounds reads** — pairs 7–11 read unrelated memory.
2. **Misaligned mapping** — the sequential assignment maps pointers to the wrong builtin slots (e.g. bitwise → ECDSA, poseidon → bitwise).
3. **Verification failure** — the verifier asserts unsupported builtins (ECDSA, EC_OP, Keccak) have empty segments, but the misaligned values show non-empty ranges.

This affects `ProgramType::Executable` programs compiled by Scarb, where the compiler only includes builtins the program actually uses. The existing `ProgramType::Json` test programs are unaffected because they declare all 11 builtins via `%builtins`.

## Fix

Replace `bootloader_context()` with `PublicSegmentContext::new(runner.get_program_builtins())`, deriving the context from the program's actual builtin declarations.

Programs that declare all builtins (bootloader, existing test fixtures) produce the same all-true context as before.

## Test plan

- [x] `cargo check` passes for the full workspace
- [ ] Existing `slow-tests` for adapter prover input comparison remain unchanged (test programs declare all 11 builtins)
- [ ] E2E prove/verify tests in `prover` crate pass (also use all-builtin test programs)

Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1666)
<!-- Reviewable:end -->
