### PR TITLE
integarte veirfy_triple_sum

### DIFF
--- a/stwo_cairo_prover/crates/cairo-air/src/components/subroutines/mod.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/components/subroutines/mod.rs
@@ -91,6 +91,7 @@ pub mod verify_add_252;
 pub mod verify_mul_252;
 pub mod verify_mul_small;
 pub mod verify_reduced_252;
+pub mod verify_triple_sum_32;
 pub mod verify_u_32;
 pub mod xor_rot_32_r_12;
 pub mod xor_rot_32_r_16;

--- a/stwo_cairo_prover/crates/cairo-air/src/components/subroutines/triple_sum_32.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/components/subroutines/triple_sum_32.rs
@@ -1,6 +1,7 @@
 // This file was created by the AIR team.
 
 use crate::components::prelude::*;
+use crate::components::subroutines::verify_triple_sum_32::VerifyTripleSum32;
 
 #[derive(Copy, Clone, Serialize, Deserialize, CairoSerialize)]
 pub struct TripleSum32 {}
@@ -19,32 +20,19 @@ impl TripleSum32 {
         common_lookup_elements: &relations::CommonLookupElements,
         eval: &mut E,
     ) -> [E::F; 0] {
-        let M31_1 = E::F::from(M31::from(1));
-        let M31_2 = E::F::from(M31::from(2));
-        let M31_32768 = E::F::from(M31::from(32768));
-
-        let carry_low_tmp_541fa_1 = eval.add_intermediate(
-            ((((triple_sum_32_input_a_limb_0.clone() + triple_sum_32_input_b_limb_0.clone())
-                + triple_sum_32_input_c_limb_0.clone())
-                - triple_sum32_res_limb_0_col0.clone())
-                * M31_32768.clone()),
-        );
-        // carry low is 0 or 1 or 2.
-        eval.add_constraint(
-            ((carry_low_tmp_541fa_1.clone() * (carry_low_tmp_541fa_1.clone() - M31_1.clone()))
-                * (carry_low_tmp_541fa_1.clone() - M31_2.clone())),
-        );
-        let carry_high_tmp_541fa_2 = eval.add_intermediate(
-            (((((triple_sum_32_input_a_limb_1.clone() + triple_sum_32_input_b_limb_1.clone())
-                + triple_sum_32_input_c_limb_1.clone())
-                + carry_low_tmp_541fa_1.clone())
-                - triple_sum32_res_limb_1_col1.clone())
-                * M31_32768.clone()),
-        );
-        // carry high is 0 or 1 or 2.
-        eval.add_constraint(
-            ((carry_high_tmp_541fa_2.clone() * (carry_high_tmp_541fa_2.clone() - M31_1.clone()))
-                * (carry_high_tmp_541fa_2.clone() - M31_2.clone())),
+        VerifyTripleSum32::evaluate(
+            [
+                triple_sum_32_input_a_limb_0.clone(),
+                triple_sum_32_input_a_limb_1.clone(),
+                triple_sum_32_input_b_limb_0.clone(),
+                triple_sum_32_input_b_limb_1.clone(),
+                triple_sum_32_input_c_limb_0.clone(),
+                triple_sum_32_input_c_limb_1.clone(),
+                triple_sum32_res_limb_0_col0.clone(),
+                triple_sum32_res_limb_1_col1.clone(),
+            ],
+            common_lookup_elements,
+            eval,
         );
         []
     }

--- a/stwo_cairo_prover/crates/cairo-air/src/components/subroutines/verify_triple_sum_32.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/components/subroutines/verify_triple_sum_32.rs
@@ -1,0 +1,51 @@
+// This file was created by the AIR team.
+
+use crate::components::prelude::*;
+
+#[derive(Copy, Clone, Serialize, Deserialize, CairoSerialize)]
+pub struct VerifyTripleSum32 {}
+
+impl VerifyTripleSum32 {
+    #[allow(unused_parens)]
+    #[allow(clippy::double_parens)]
+    #[allow(non_snake_case)]
+    #[allow(clippy::unused_unit)]
+    #[allow(unused_variables)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn evaluate<E: EvalAtRow>(
+        [verify_triple_sum_32_input_limb_0, verify_triple_sum_32_input_limb_1, verify_triple_sum_32_input_limb_2, verify_triple_sum_32_input_limb_3, verify_triple_sum_32_input_limb_4, verify_triple_sum_32_input_limb_5, verify_triple_sum_32_input_limb_6, verify_triple_sum_32_input_limb_7]: [E::F; 8],
+        common_lookup_elements: &relations::CommonLookupElements,
+        eval: &mut E,
+    ) -> [E::F; 0] {
+        let M31_1 = E::F::from(M31::from(1));
+        let M31_2 = E::F::from(M31::from(2));
+        let M31_32768 = E::F::from(M31::from(32768));
+
+        let carry_low_tmp_24c23_0 = eval.add_intermediate(
+            ((((verify_triple_sum_32_input_limb_0.clone()
+                + verify_triple_sum_32_input_limb_2.clone())
+                + verify_triple_sum_32_input_limb_4.clone())
+                - verify_triple_sum_32_input_limb_6.clone())
+                * M31_32768.clone()),
+        );
+        // carry low is 0 or 1 or 2.
+        eval.add_constraint(
+            ((carry_low_tmp_24c23_0.clone() * (carry_low_tmp_24c23_0.clone() - M31_1.clone()))
+                * (carry_low_tmp_24c23_0.clone() - M31_2.clone())),
+        );
+        let carry_high_tmp_24c23_1 = eval.add_intermediate(
+            (((((verify_triple_sum_32_input_limb_1.clone()
+                + verify_triple_sum_32_input_limb_3.clone())
+                + verify_triple_sum_32_input_limb_5.clone())
+                + carry_low_tmp_24c23_0.clone())
+                - verify_triple_sum_32_input_limb_7.clone())
+                * M31_32768.clone()),
+        );
+        // carry high is 0 or 1 or 2.
+        eval.add_constraint(
+            ((carry_high_tmp_24c23_1.clone() * (carry_high_tmp_24c23_1.clone() - M31_1.clone()))
+                * (carry_high_tmp_24c23_1.clone() - M31_2.clone())),
+        );
+        []
+    }
+}

--- a/stwo_cairo_prover/crates/common/casm_registry.json
+++ b/stwo_cairo_prover/crates/common/casm_registry.json
@@ -1,5 +1,5 @@
 {
-  "air_version": "a7ee9a78",
+  "air_version": "e2f68b59",
   "canonical_ppt_n_trace_cells": 543100528,
   "canonical_without_pedersen_ppt_n_trace_cells": 73338480,
   "air_fns": {

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/sample_evaluations.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/sample_evaluations.cairo
@@ -1,4 +1,4 @@
-// AIR version a7ee9a78
+// AIR version e2f68b59
 use stwo_verifier_core::fields::m31::M31;
 pub const ADD_AP_OPCODE_SAMPLE_EVAL_RESULT: [M31; 4] = [
     M31 { inner: 1435814162 }, M31 { inner: 1618992457 }, M31 { inner: 840348268 },

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/subroutines.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/subroutines.cairo
@@ -91,6 +91,7 @@ pub mod verify_add_252;
 pub mod verify_mul_252;
 pub mod verify_mul_small;
 pub mod verify_reduced_252;
+pub mod verify_triple_sum_32;
 pub mod verify_u_32;
 pub mod xor_rot_32_r_12;
 pub mod xor_rot_32_r_16;

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/subroutines/triple_sum_32.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/subroutines/triple_sum_32.cairo
@@ -1,5 +1,6 @@
 // This file was created by the AIR team.
 
+use crate::components::subroutines::verify_triple_sum_32::verify_triple_sum_32_evaluate;
 use crate::prelude::*;
 
 
@@ -20,29 +21,17 @@ pub fn triple_sum_32_evaluate(
         triple_sum_32_input_c_limb_1,
     ] =
         input;
-    let carry_low_tmp_541fa_1: QM31 = ((((triple_sum_32_input_a_limb_0
-        + triple_sum_32_input_b_limb_0)
-        + triple_sum_32_input_c_limb_0)
-        - triple_sum32_res_limb_0_col0)
-        * qm31_const::<32768, 0, 0, 0>());
-
-    // Constraint - carry low is 0 or 1 or 2
-    let constraint_quotient = (((carry_low_tmp_541fa_1
-        * (carry_low_tmp_541fa_1 - qm31_const::<1, 0, 0, 0>()))
-        * (carry_low_tmp_541fa_1 - qm31_const::<2, 0, 0, 0>())));
-    sum = sum * random_coeff + constraint_quotient;
-    let carry_high_tmp_541fa_2: QM31 = (((((triple_sum_32_input_a_limb_1
-        + triple_sum_32_input_b_limb_1)
-        + triple_sum_32_input_c_limb_1)
-        + carry_low_tmp_541fa_1)
-        - triple_sum32_res_limb_1_col1)
-        * qm31_const::<32768, 0, 0, 0>());
-
-    // Constraint - carry high is 0 or 1 or 2
-    let constraint_quotient = (((carry_high_tmp_541fa_2
-        * (carry_high_tmp_541fa_2 - qm31_const::<1, 0, 0, 0>()))
-        * (carry_high_tmp_541fa_2 - qm31_const::<2, 0, 0, 0>())));
-    sum = sum * random_coeff + constraint_quotient;
+    verify_triple_sum_32_evaluate(
+        [
+            triple_sum_32_input_a_limb_0, triple_sum_32_input_a_limb_1,
+            triple_sum_32_input_b_limb_0, triple_sum_32_input_b_limb_1,
+            triple_sum_32_input_c_limb_0, triple_sum_32_input_c_limb_1,
+            triple_sum32_res_limb_0_col0, triple_sum32_res_limb_1_col1,
+        ],
+        common_lookup_elements,
+        ref sum,
+        random_coeff,
+    );
 
     []
 }

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/subroutines/verify_triple_sum_32.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/subroutines/verify_triple_sum_32.cairo
@@ -1,0 +1,48 @@
+// This file was created by the AIR team.
+
+use crate::prelude::*;
+
+
+pub fn verify_triple_sum_32_evaluate(
+    input: [QM31; 8],
+    common_lookup_elements: @CommonLookupElements,
+    ref sum: QM31,
+    random_coeff: QM31,
+) -> [QM31; 0] {
+    let [
+        verify_triple_sum_32_input_limb_0,
+        verify_triple_sum_32_input_limb_1,
+        verify_triple_sum_32_input_limb_2,
+        verify_triple_sum_32_input_limb_3,
+        verify_triple_sum_32_input_limb_4,
+        verify_triple_sum_32_input_limb_5,
+        verify_triple_sum_32_input_limb_6,
+        verify_triple_sum_32_input_limb_7,
+    ] =
+        input;
+    let carry_low_tmp_24c23_0: QM31 = ((((verify_triple_sum_32_input_limb_0
+        + verify_triple_sum_32_input_limb_2)
+        + verify_triple_sum_32_input_limb_4)
+        - verify_triple_sum_32_input_limb_6)
+        * qm31_const::<32768, 0, 0, 0>());
+
+    // Constraint - carry low is 0 or 1 or 2
+    let constraint_quotient = (((carry_low_tmp_24c23_0
+        * (carry_low_tmp_24c23_0 - qm31_const::<1, 0, 0, 0>()))
+        * (carry_low_tmp_24c23_0 - qm31_const::<2, 0, 0, 0>())));
+    sum = sum * random_coeff + constraint_quotient;
+    let carry_high_tmp_24c23_1: QM31 = (((((verify_triple_sum_32_input_limb_1
+        + verify_triple_sum_32_input_limb_3)
+        + verify_triple_sum_32_input_limb_5)
+        + carry_low_tmp_24c23_0)
+        - verify_triple_sum_32_input_limb_7)
+        * qm31_const::<32768, 0, 0, 0>());
+
+    // Constraint - carry high is 0 or 1 or 2
+    let constraint_quotient = (((carry_high_tmp_24c23_1
+        * (carry_high_tmp_24c23_1 - qm31_const::<1, 0, 0, 0>()))
+        * (carry_high_tmp_24c23_1 - qm31_const::<2, 0, 0, 0>())));
+    sum = sum * random_coeff + constraint_quotient;
+
+    []
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1716)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AIR constraint evaluation for `triple_sum_32` by moving carry/constraint logic into a shared verifier-style subroutine; a wiring/input-order mistake could invalidate proofs even though the math is unchanged.
> 
> **Overview**
> Refactors the `triple_sum_32` AIR subroutine to delegate its carry/constraint checks to a new shared `verify_triple_sum_32` implementation (added in both the prover Rust code and the verifier Cairo code), reducing duplicated constraint logic.
> 
> Updates module exports to include `verify_triple_sum_32`, and bumps the recorded `air_version` in `casm_registry.json` and the verifier’s `sample_evaluations.cairo` header accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 686a6b7dd5464c392a09e00d19f27fca307f7534. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->