### PR TITLE
Move generic AIR traits/types from cairo_air to constraint_framework.

### DIFF
--- a/stwo_cairo_verifier/crates/cairo_air/src/blake.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/blake.cairo
@@ -4,11 +4,10 @@ use components::blake_round_sigma::InteractionClaimImpl as BlakeRoundSigmaIntera
 use components::triple_xor_32::InteractionClaimImpl as TripleXor32InteractionClaimImpl;
 use components::verify_bitwise_xor_12::InteractionClaimImpl as VerifyBitwiseXor12InteractionClaimImpl;
 use core::array::Span;
-use stwo_cairo_air::cairo_component::CairoComponent;
 use stwo_cairo_air::claims::{CairoClaim, CairoInteractionClaim};
 use stwo_cairo_air::components;
 use stwo_constraint_framework::{
-    CommonLookupElements, PreprocessedMaskValues, PreprocessedMaskValuesImpl,
+    AirComponent, CommonLookupElements, PreprocessedMaskValues, PreprocessedMaskValuesImpl,
 };
 use stwo_verifier_core::ColumnSpan;
 use stwo_verifier_core::fields::qm31::QM31;

--- a/stwo_cairo_verifier/crates/cairo_air/src/builtins.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/builtins.cairo
@@ -7,11 +7,11 @@ use components::range_check96_builtin::InteractionClaimImpl as RangeCheckBuiltin
 use components::range_check_builtin::InteractionClaimImpl as RangeCheckBuiltinBits128InteractionClaimImpl;
 use core::array::Span;
 use core::box::BoxImpl;
-use stwo_cairo_air::cairo_component::CairoComponent;
 use stwo_cairo_air::claims::{CairoClaim, CairoInteractionClaim};
 use stwo_cairo_air::components;
 use stwo_constraint_framework::{
-    CommonLookupElements, LookupElementsImpl, PreprocessedMaskValues, PreprocessedMaskValuesImpl,
+    AirComponent, CommonLookupElements, LookupElementsImpl, PreprocessedMaskValues,
+    PreprocessedMaskValuesImpl,
 };
 use stwo_verifier_core::ColumnSpan;
 use stwo_verifier_core::fields::qm31::QM31;

--- a/stwo_cairo_verifier/crates/cairo_air/src/cairo_air.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/cairo_air.cairo
@@ -15,7 +15,6 @@ use core::num::traits::Zero;
 use core::traits::TryInto;
 use stwo_cairo_air::blake::{BlakeContextComponents, BlakeContextComponentsImpl};
 use stwo_cairo_air::builtins::{BuiltinComponents, BuiltinComponentsImpl};
-use stwo_cairo_air::cairo_component::CairoComponent;
 use stwo_cairo_air::opcodes::{OpcodeComponents, OpcodeComponentsImpl};
 use stwo_verifier_core::fields::m31::M31;
 use crate::P_U32;
@@ -36,7 +35,7 @@ use stwo_cairo_air::preprocessed_columns::PREPROCESSED_COLUMN_LOG_SIZE;
 use stwo_cairo_air::range_checks::{RangeChecksComponents, RangeChecksComponentsImpl};
 use stwo_cairo_air::{PublicDataImpl, components};
 use stwo_constraint_framework::{
-    LookupElementsImpl, PreprocessedMaskValues, PreprocessedMaskValuesImpl,
+    AirComponent, LookupElementsImpl, PreprocessedMaskValues, PreprocessedMaskValuesImpl,
 };
 use stwo_verifier_core::circle::CirclePoint;
 use stwo_verifier_core::fields::qm31::QM31;

--- a/stwo_cairo_verifier/crates/cairo_air/src/claim.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/claim.cairo
@@ -1,25 +1,7 @@
 use core::array::Span;
-use stwo_verifier_core::TreeArray;
 use stwo_verifier_core::channel::{Channel, ChannelTrait};
 use stwo_verifier_core::utils::{OptionImpl, pack_into_qm31s};
-use crate::{PublicData, PublicDataImpl, RelationUsesDict};
-
-/// Trait that defines the functionality required by a "claim",
-/// where a "claim" is an object that holds public information about
-/// one or multiple components whose trace needs to be verified.
-pub trait ClaimTrait<T> {
-    /// Mix this claim’s public data into the verification transcript (`channel`),
-    /// ensuring it influences all subsequently derived challenges.
-    fn mix_into(self: @T, ref channel: Channel);
-    /// Return the log₂ sizes of the columns in all components of this claim.
-    ///
-    /// Columns are grouped first by tree, then by column within each tree.
-    /// For example, if `claim.log_sizes()[i][j] == n`, the `j`-th column in the
-    /// `i`-th tree has size `2^n`.
-    fn log_sizes(self: @T) -> TreeArray<Span<u32>>;
-    /// Record the lookups used by the components associated with the claim.
-    fn accumulate_relation_uses(self: @T, ref relation_uses: RelationUsesDict);
-}
+use crate::{PublicData, PublicDataImpl};
 
 #[derive(Serde, Drop)]
 pub struct FlatClaim {

--- a/stwo_cairo_verifier/crates/cairo_air/src/claims.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/claims.cairo
@@ -1,8 +1,9 @@
 // This file was created by the AIR team.
 
-use stwo_cairo_air::claim::ClaimTrait;
-use stwo_cairo_air::{PublicData, PublicDataImpl, RelationUsesDict};
-use stwo_constraint_framework::CommonLookupElements;
+use stwo_cairo_air::{PublicData, PublicDataImpl};
+use stwo_constraint_framework::{
+    ClaimTrait, CommonLookupElements, RelationUsesDict, tree_array_concat_cols,
+};
 use stwo_verifier_core::TreeArray;
 use stwo_verifier_core::channel::Channel;
 use stwo_verifier_core::fields::qm31::QM31;
@@ -28,7 +29,6 @@ use crate::components::{
     verify_bitwise_xor_4, verify_bitwise_xor_7, verify_bitwise_xor_8, verify_bitwise_xor_9,
     verify_instruction,
 };
-use crate::utils::tree_array_concat_cols;
 use crate::{ChannelTrait, PublicDataTrait, components};
 use super::claim::{FlatClaim, FlatClaimTrait};
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/add_ap_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/add_ap_opcode.cairo
@@ -71,7 +71,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -365,12 +365,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/add_mod_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/add_mod_builtin.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -2208,12 +2208,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/add_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/add_opcode.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -698,12 +698,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/add_opcode_small.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/add_opcode_small.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -485,12 +485,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/assert_eq_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/assert_eq_opcode.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -305,12 +305,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/assert_eq_opcode_double_deref.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/assert_eq_opcode_double_deref.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -378,12 +378,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/assert_eq_opcode_imm.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/assert_eq_opcode_imm.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -287,12 +287,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/bitwise_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/bitwise_builtin.cairo
@@ -74,7 +74,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -1375,12 +1375,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/blake_compress_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/blake_compress_opcode.cairo
@@ -73,7 +73,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -2326,12 +2326,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/blake_g.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/blake_g.cairo
@@ -73,7 +73,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -717,12 +717,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/blake_round.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/blake_round.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -2310,12 +2310,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/blake_round_sigma.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/blake_round_sigma.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -162,12 +162,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/call_opcode_abs.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/call_opcode_abs.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -456,12 +456,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/call_opcode_rel_imm.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/call_opcode_rel_imm.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -455,12 +455,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/cube_252.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/cube_252.cairo
@@ -71,7 +71,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -2522,12 +2522,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/ec_op_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/ec_op_builtin.cairo
@@ -72,7 +72,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -1957,12 +1957,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/generic_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/generic_opcode.cairo
@@ -76,7 +76,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -2260,12 +2260,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/jnz_opcode_non_taken.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/jnz_opcode_non_taken.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -296,12 +296,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/jnz_opcode_taken.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/jnz_opcode_taken.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -487,12 +487,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_abs.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_abs.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -305,12 +305,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_double_deref.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_double_deref.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -376,12 +376,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_rel.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_rel.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -309,12 +309,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_rel_imm.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_rel_imm.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -291,12 +291,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/memory_address_to_id.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/memory_address_to_id.cairo
@@ -85,7 +85,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/memory_id_to_big.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/memory_id_to_big.cairo
@@ -1,13 +1,13 @@
-use stwo_constraint_framework::{PreprocessedMaskValues, PreprocessedMaskValuesImpl};
+use stwo_constraint_framework::{
+    AirComponent, ClaimTrait, PreprocessedMaskValues, PreprocessedMaskValuesImpl, RelationUsesDict,
+    accumulate_relation_uses,
+};
 use stwo_verifier_core::channel::Channel;
 use stwo_verifier_core::fields::qm31::{QM31, QM31Serde, QM31_EXTENSION_DEGREE};
 use stwo_verifier_core::poly::circle::CanonicCosetImpl;
 use stwo_verifier_core::utils::{ArrayImpl, pow2};
 use stwo_verifier_core::{ColumnSpan, TreeArray};
-use crate::cairo_component::CairoComponent;
-use crate::claim::ClaimTrait;
 use crate::prelude::*;
-use crate::{RelationUsesDict, accumulate_relation_uses};
 use super::super::utils::UsizeImpl;
 
 mod constraints_big;
@@ -118,7 +118,7 @@ pub impl NewBigComponentImpl of NewBigComponent {
     }
 }
 
-pub impl CairoBigComponentImpl of CairoComponent<BigComponent> {
+pub impl CairoBigComponentImpl of AirComponent<BigComponent> {
     fn evaluate_constraints_at_point(
         self: @BigComponent,
         ref sum: QM31,

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/memory_id_to_small.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/memory_id_to_small.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -290,12 +290,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/mul_mod_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/mul_mod_builtin.cairo
@@ -73,7 +73,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -6560,12 +6560,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/mul_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/mul_opcode.cairo
@@ -72,7 +72,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -1285,12 +1285,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/mul_opcode_small.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/mul_opcode_small.cairo
@@ -72,7 +72,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -531,12 +531,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/partial_ec_mul_generic.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/partial_ec_mul_generic.cairo
@@ -75,7 +75,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -8791,12 +8791,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/partial_ec_mul_window_bits_18.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/partial_ec_mul_window_bits_18.cairo
@@ -73,7 +73,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -3709,12 +3709,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/partial_ec_mul_window_bits_9.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/partial_ec_mul_window_bits_9.cairo
@@ -73,7 +73,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -3746,12 +3746,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_aggregator_window_bits_18.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_aggregator_window_bits_18.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -1761,12 +1761,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_aggregator_window_bits_9.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_aggregator_window_bits_9.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -1946,12 +1946,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_builtin.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -241,12 +241,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_builtin_narrow_windows.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_builtin_narrow_windows.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -241,12 +241,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_points_table_window_bits_18.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_points_table_window_bits_18.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -213,12 +213,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_points_table_window_bits_9.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_points_table_window_bits_9.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_3_partial_rounds_chain.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_3_partial_rounds_chain.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -1402,12 +1402,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_aggregator.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_aggregator.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -2638,12 +2638,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_builtin.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -339,12 +339,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_full_round_chain.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_full_round_chain.cairo
@@ -71,7 +71,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -1116,12 +1116,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_round_keys.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_round_keys.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -213,12 +213,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/qm_31_add_mul_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/qm_31_add_mul_opcode.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -726,12 +726,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check96_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check96_builtin.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -237,12 +237,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_11.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_11.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -138,12 +138,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_12.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_12.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -138,12 +138,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_18.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_18.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -154,12 +154,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_20.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_20.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -299,12 +299,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_252_width_27.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_252_width_27.cairo
@@ -68,7 +68,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -582,12 +582,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_3_3_3_3_3.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_3_3_3_3_3.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -154,12 +154,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_3_6_6_3.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_3_6_6_3.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -152,12 +152,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_4_3.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_4_3.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -147,12 +147,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_4_4.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_4_4.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -147,12 +147,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_4_4_4_4.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_4_4_4_4.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -152,12 +152,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_6.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_6.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -138,12 +138,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_7_2_5.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_7_2_5.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -149,12 +149,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_8.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_8.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -138,12 +138,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_9_9.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_9_9.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -350,12 +350,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_builtin.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -224,12 +224,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/ret_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/ret_opcode.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -348,12 +348,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/triple_xor_32.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/triple_xor_32.cairo
@@ -70,7 +70,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -441,12 +441,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_12.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_12.cairo
@@ -62,7 +62,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_4.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_4.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -146,12 +146,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_7.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_7.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -146,12 +146,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_8.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_8.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -168,12 +168,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_9.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_9.cairo
@@ -59,7 +59,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -146,12 +146,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/verify_instruction.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/verify_instruction.cairo
@@ -69,7 +69,7 @@ pub impl NewComponentImpl of NewComponent<Component> {
     }
 }
 
-pub impl CairoComponentImpl of CairoComponent<Component> {
+pub impl AirComponentImpl of AirComponent<Component> {
     fn evaluate_constraints_at_point(
         self: @Component,
         ref sum: QM31,
@@ -307,12 +307,12 @@ mod tests {
     use core::num::traits::Zero;
     #[allow(unused_imports)]
     use stwo_cairo_air::preprocessed_columns::*;
+    use stwo_constraint_framework::AirComponent;
     #[allow(unused_imports)]
     use stwo_constraint_framework::{
         LookupElementsTrait, PreprocessedMaskValues, PreprocessedMaskValuesTrait,
     };
     use stwo_verifier_core::fields::qm31::{QM31, QM31Impl, QM31Trait, qm31_const};
-    use crate::cairo_component::*;
     use crate::components::sample_evaluations::*;
     #[allow(unused_imports)]
     use crate::test_utils::{make_interaction_trace, preprocessed_mask_add};

--- a/stwo_cairo_verifier/crates/cairo_air/src/lib.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/lib.cairo
@@ -26,13 +26,13 @@ mod blake2s_verifier_uses {
 #[cfg(not(feature: "poseidon252_verifier"))]
 use blake2s_verifier_uses::*;
 use core::box::BoxImpl;
-use core::dict::{Felt252Dict, Felt252DictEntryTrait, Felt252DictTrait, SquashedFelt252DictTrait};
+use core::dict::{Felt252DictTrait, SquashedFelt252DictTrait};
 use core::iter::{Extend, Iterator};
 use core::num::traits::Zero;
 use core::num::traits::one::One;
 use core::traits::TryInto;
 use stwo_constraint_framework::{
-    CommonLookupElements, LookupElementsImpl, PreprocessedMaskValuesImpl,
+    CommonLookupElements, LookupElementsImpl, PreprocessedMaskValuesImpl, RelationUsesDict,
 };
 use stwo_verifier_core::channel::{Channel, ChannelImpl, ChannelTrait};
 use stwo_verifier_core::fields::Invertible;
@@ -74,7 +74,6 @@ use claims::{
 pub mod cairo_air;
 use cairo_air::*;
 
-pub mod cairo_component;
 pub mod components;
 
 // This module checks the validity of feature combinations. It's placed in this crate since it's the
@@ -122,13 +121,6 @@ pub mod claim;
 mod preprocessed_columns_canonical;
 #[cfg(feature: "poseidon252_verifier")]
 mod preprocessed_columns_without_pedersen;
-
-// A dict from relation_id, which is a string encoded as a felt252, to the number of uses of the
-// corresponding relation.
-type RelationUsesDict = Felt252Dict<u64>;
-
-// A tuple of (relation_id, uses).
-type RelationUse = (felt252, u32);
 
 #[derive(Drop, Serde)]
 pub struct CairoProof {
@@ -1024,17 +1016,6 @@ impl CasmStateImpl of CasmStateTrait {
         channel.mix_u64(pc_u32.into());
         channel.mix_u64(ap_u32.into());
         channel.mix_u64(fp_u32.into());
-    }
-}
-
-pub fn accumulate_relation_uses(
-    ref relation_uses: RelationUsesDict, relation_uses_per_row: Span<RelationUse>, log_size: u32,
-) {
-    let component_size = pow2(log_size);
-    for relation_use in relation_uses_per_row {
-        let (relation_id, uses) = *relation_use;
-        let (entry, prev_uses) = relation_uses.entry(relation_id);
-        relation_uses = entry.finalize(prev_uses + uses.into() * component_size.into());
     }
 }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/opcodes.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/opcodes.cairo
@@ -21,11 +21,11 @@ use components::ret_opcode::InteractionClaimImpl as RetOpcodeInteractionClaimImp
 use core::array::Span;
 use core::box::BoxImpl;
 use core::iter::{IntoIterator, Iterator};
-use stwo_cairo_air::cairo_component::CairoComponent;
 use stwo_cairo_air::claims::{CairoClaim, CairoInteractionClaim};
 use stwo_cairo_air::components;
 use stwo_constraint_framework::{
-    CommonLookupElements, LookupElementsImpl, PreprocessedMaskValues, PreprocessedMaskValuesImpl,
+    AirComponent, CommonLookupElements, LookupElementsImpl, PreprocessedMaskValues,
+    PreprocessedMaskValuesImpl,
 };
 use stwo_verifier_core::ColumnSpan;
 use stwo_verifier_core::fields::qm31::QM31;

--- a/stwo_cairo_verifier/crates/cairo_air/src/pedersen.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/pedersen.cairo
@@ -5,13 +5,11 @@ use components::pedersen_points_table_window_bits_18::InteractionClaimImpl as Pe
 #[cfg(not(feature: "poseidon252_verifier"))]
 use core::array::Span;
 #[cfg(not(feature: "poseidon252_verifier"))]
-use stwo_cairo_air::cairo_component::CairoComponent;
-#[cfg(not(feature: "poseidon252_verifier"))]
 use stwo_cairo_air::claims::{CairoClaim, CairoInteractionClaim};
 use stwo_cairo_air::components;
 use stwo_constraint_framework::PreprocessedMaskValuesImpl;
 #[cfg(not(feature: "poseidon252_verifier"))]
-use stwo_constraint_framework::{CommonLookupElements, PreprocessedMaskValues};
+use stwo_constraint_framework::{AirComponent, CommonLookupElements, PreprocessedMaskValues};
 #[cfg(not(feature: "poseidon252_verifier"))]
 use stwo_verifier_core::ColumnSpan;
 #[cfg(not(feature: "poseidon252_verifier"))]

--- a/stwo_cairo_verifier/crates/cairo_air/src/poseidon.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/poseidon.cairo
@@ -8,13 +8,11 @@ use components::range_check_252_width_27::InteractionClaimImpl as RangeCheckFelt
 #[cfg(not(feature: "poseidon252_verifier"))]
 use core::array::Span;
 #[cfg(or(not(feature: "poseidon252_verifier"), feature: "poseidon_outputs_packing"))]
-use stwo_cairo_air::cairo_component::CairoComponent;
-#[cfg(or(not(feature: "poseidon252_verifier"), feature: "poseidon_outputs_packing"))]
 use stwo_cairo_air::claims::{CairoClaim, CairoInteractionClaim};
 use stwo_cairo_air::components;
 use stwo_constraint_framework::PreprocessedMaskValuesImpl;
 #[cfg(or(not(feature: "poseidon252_verifier"), feature: "poseidon_outputs_packing"))]
-use stwo_constraint_framework::{CommonLookupElements, PreprocessedMaskValues};
+use stwo_constraint_framework::{AirComponent, CommonLookupElements, PreprocessedMaskValues};
 #[cfg(or(not(feature: "poseidon252_verifier"), feature: "poseidon_outputs_packing"))]
 use stwo_verifier_core::ColumnSpan;
 #[cfg(or(not(feature: "poseidon252_verifier"), feature: "poseidon_outputs_packing"))]

--- a/stwo_cairo_verifier/crates/cairo_air/src/prelude.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/prelude.cairo
@@ -1,6 +1,7 @@
 pub use core::num::traits::Zero;
 pub use stwo_constraint_framework::{
-    CommonLookupElements, LookupElementsImpl, PreprocessedMaskValues, PreprocessedMaskValuesImpl,
+    AirComponent, ClaimTrait, CommonLookupElements, LookupElementsImpl, NewComponent,
+    PreprocessedMaskValues, PreprocessedMaskValuesImpl, RelationUsesDict, accumulate_relation_uses,
 };
 pub use stwo_verifier_core::channel::{Channel, ChannelTrait};
 pub use stwo_verifier_core::circle::{
@@ -16,8 +17,6 @@ pub use stwo_verifier_core::fields::qm31::{
 pub use stwo_verifier_core::poly::circle::CanonicCosetImpl;
 pub use stwo_verifier_core::utils::{ArrayImpl, pow2};
 pub use stwo_verifier_core::{ColumnArray, ColumnSpan, TreeArray};
-pub use crate::cairo_component::{CairoComponent, NewComponent};
-pub use crate::claim::ClaimTrait;
 pub use crate::components::subroutines::*;
+pub use crate::preprocessed_columns;
 pub use crate::preprocessed_columns::*;
-pub use crate::{RelationUsesDict, accumulate_relation_uses, preprocessed_columns};

--- a/stwo_cairo_verifier/crates/cairo_air/src/range_checks.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/range_checks.cairo
@@ -15,11 +15,10 @@ use components::range_check_8::InteractionClaimImpl as RangeCheck_8InteractionCl
 use components::range_check_9_9::InteractionClaimImpl as RangeCheck_9_9InteractionClaimImpl;
 use components::range_check_builtin::InteractionClaimImpl as RangeCheckBuiltinInteractionClaimImpl;
 use core::array::Span;
-use stwo_cairo_air::cairo_component::CairoComponent;
 use stwo_cairo_air::claims::{CairoClaim, CairoInteractionClaim};
 use stwo_cairo_air::components;
 use stwo_constraint_framework::{
-    CommonLookupElements, PreprocessedMaskValues, PreprocessedMaskValuesImpl,
+    AirComponent, CommonLookupElements, PreprocessedMaskValues, PreprocessedMaskValuesImpl,
 };
 use stwo_verifier_core::ColumnSpan;
 use stwo_verifier_core::fields::qm31::QM31;

--- a/stwo_cairo_verifier/crates/cairo_air/src/test.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/test.cairo
@@ -5,8 +5,9 @@ use stwo_cairo_air::components::memory_address_to_id::{
 };
 use stwo_cairo_air::{
     CasmState, MemorySmallValue, PublicData, PublicDataImpl, PublicMemory, PublicSegmentRanges,
-    RelationUsesDict, SegmentRange, accumulate_relation_uses,
+    SegmentRange,
 };
+use stwo_constraint_framework::{RelationUsesDict, accumulate_relation_uses};
 use stwo_verifier_core::fields::m31::M31Trait;
 use stwo_verifier_core::fields::qm31::qm31_const;
 use stwo_verifier_core::utils::ArrayImpl;

--- a/stwo_cairo_verifier/crates/cairo_air/src/utils.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/utils.cairo
@@ -2,7 +2,6 @@ use core::array::ToSpanTrait;
 use core::iter::{IntoIterator, Iterator};
 use core::num::traits::WrappingMul;
 use core::traits::DivRem;
-use stwo_verifier_core::TreeArray;
 use stwo_verifier_core::fields::m31::M31;
 use stwo_verifier_core::fields::qm31::{QM31, QM31Trait};
 use stwo_verifier_core::utils::pow2;
@@ -26,30 +25,6 @@ pub impl UsizeImpl of UsizeExTrait {
             d
         }
     }
-}
-
-pub fn tree_array_concat_cols(tree_array: Array<TreeArray<Span<u32>>>) -> TreeArray<Span<u32>> {
-    let mut tree0 = array![];
-    let mut tree1 = array![];
-    let mut tree2 = array![];
-
-    for curr_tree in tree_array.span() {
-        // TODO: Instead of changing this to make it generic just refactor so the
-        // whole function can be removed.
-        assert!(curr_tree.len() <= 3);
-
-        if curr_tree.len() > 0 {
-            tree0.append_span(*curr_tree[0]);
-        }
-        if curr_tree.len() > 1 {
-            tree1.append_span(*curr_tree[1]);
-        }
-        if curr_tree.len() > 2 {
-            tree2.append_span(*curr_tree[2]);
-        }
-    }
-
-    array![tree0.span(), tree1.span(), tree2.span()]
 }
 
 /// Splits a 252 bit dense representation into felts, each with `N_BITS_PER_FELT` bits.

--- a/stwo_cairo_verifier/crates/constraint_framework/src/claim.cairo
+++ b/stwo_cairo_verifier/crates/constraint_framework/src/claim.cairo
@@ -1,0 +1,21 @@
+use core::array::Span;
+use stwo_verifier_core::TreeArray;
+use stwo_verifier_core::channel::Channel;
+use crate::RelationUsesDict;
+
+/// Trait that defines the functionality required by a "claim",
+/// where a "claim" is an object that holds public information about
+/// one or multiple components whose trace needs to be verified.
+pub trait ClaimTrait<T> {
+    /// Mix this claim’s public data into the verification transcript (`channel`),
+    /// ensuring it influences all subsequently derived challenges.
+    fn mix_into(self: @T, ref channel: Channel);
+    /// Return the log₂ sizes of the columns in all components of this claim.
+    ///
+    /// Columns are grouped first by tree, then by column within each tree.
+    /// For example, if `claim.log_sizes()[i][j] == n`, the `j`-th column in the
+    /// `i`-th tree has size `2^n`.
+    fn log_sizes(self: @T) -> TreeArray<Span<u32>>;
+    /// Record the lookups used by the components associated with the claim.
+    fn accumulate_relation_uses(self: @T, ref relation_uses: RelationUsesDict);
+}

--- a/stwo_cairo_verifier/crates/constraint_framework/src/component.cairo
+++ b/stwo_cairo_verifier/crates/constraint_framework/src/component.cairo
@@ -1,9 +1,9 @@
-use stwo_constraint_framework::{CommonLookupElements, PreprocessedMaskValues};
 use stwo_verifier_core::ColumnSpan;
 use stwo_verifier_core::fields::qm31::QM31;
+use crate::{CommonLookupElements, PreprocessedMaskValues};
 
 /// A component is a set of trace columns of the same sizes along with a set of constraints on them.
-pub trait CairoComponent<T> {
+pub trait AirComponent<T> {
     fn evaluate_constraints_at_point(
         self: @T,
         ref sum: QM31,

--- a/stwo_cairo_verifier/crates/constraint_framework/src/lib.cairo
+++ b/stwo_cairo_verifier/crates/constraint_framework/src/lib.cairo
@@ -7,7 +7,15 @@ use stwo_verifier_core::fields::m31::M31;
 #[cfg(not(feature: "qm31_opcode"))]
 use stwo_verifier_core::fields::m31::MulByM31Trait;
 use stwo_verifier_core::fields::qm31::QM31;
-use stwo_verifier_core::utils::ArrayImpl;
+use stwo_verifier_core::utils::{ArrayImpl, pow2};
+
+pub mod claim;
+pub mod component;
+pub mod utils;
+
+pub use claim::ClaimTrait;
+pub use component::{AirComponent, NewComponent};
+pub use utils::tree_array_concat_cols;
 
 /// Represents the value of the prefix sum column at some index.
 /// Should be used to eliminate padded rows for the logup sum.
@@ -173,4 +181,22 @@ pub type PreprocessedColumnIdx = u32;
 
 // Used for columns not present in the preprocessed trace
 pub const INVALID_COLUMN_IDX: PreprocessedColumnIdx = 1000000000;
+
+// A dict from relation_id, which is a string encoded as a felt252, to the number of uses of the
+// corresponding relation.
+pub type RelationUsesDict = Felt252Dict<u64>;
+
+// A tuple of (relation_id, uses).
+pub type RelationUse = (felt252, u32);
+
+pub fn accumulate_relation_uses(
+    ref relation_uses: RelationUsesDict, relation_uses_per_row: Span<RelationUse>, log_size: u32,
+) {
+    let component_size = pow2(log_size);
+    for relation_use in relation_uses_per_row {
+        let (relation_id, uses) = *relation_use;
+        let (entry, prev_uses) = relation_uses.entry(relation_id);
+        relation_uses = entry.finalize(prev_uses + uses.into() * component_size.into());
+    }
+}
 

--- a/stwo_cairo_verifier/crates/constraint_framework/src/utils.cairo
+++ b/stwo_cairo_verifier/crates/constraint_framework/src/utils.cairo
@@ -1,0 +1,25 @@
+use stwo_verifier_core::TreeArray;
+
+pub fn tree_array_concat_cols(tree_array: Array<TreeArray<Span<u32>>>) -> TreeArray<Span<u32>> {
+    let mut tree0 = array![];
+    let mut tree1 = array![];
+    let mut tree2 = array![];
+
+    for curr_tree in tree_array.span() {
+        // TODO: Instead of changing this to make it generic just refactor so the
+        // whole function can be removed.
+        assert!(curr_tree.len() <= 3);
+
+        if curr_tree.len() > 0 {
+            tree0.append_span(*curr_tree[0]);
+        }
+        if curr_tree.len() > 1 {
+            tree1.append_span(*curr_tree[1]);
+        }
+        if curr_tree.len() > 2 {
+            tree2.append_span(*curr_tree[2]);
+        }
+    }
+
+    array![tree0.span(), tree1.span(), tree2.span()]
+}


### PR DESCRIPTION
Hoists AirComponent (renamed from CairoComponent), NewComponent, ClaimTrait,
InteractionClaimTrait, RelationUsesDict, RelationUse, accumulate_relation_uses,
and tree_array_concat_cols into stwo_constraint_framework so they can be shared
with the upcoming circuit_air verifier crate. cairo_air re-exports them under
the legacy names so the auto-generated component files continue to compile
unchanged.

Pure refactor — no behavior change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1751)
<!-- Reviewable:end -->
