### PR TITLE
Add opt_n_id_to_big_components prover parameter

### DIFF
--- a/stwo_cairo_prover/crates/prover/src/debug_tools/assert_constraints.rs
+++ b/stwo_cairo_prover/crates/prover/src/debug_tools/assert_constraints.rs
@@ -267,7 +267,7 @@ pub fn assert_cairo_constraints(input: ProverInput, preprocessed_trace: Arc<PreP
     // Base trace.
     let cairo_claim_generator = create_cairo_claim_generator(input, preprocessed_trace.clone());
     let mut tree_builder = commitment_scheme.tree_builder();
-    let (trace_evals, claim, interaction_generator) = cairo_claim_generator.write_trace();
+    let (trace_evals, claim, interaction_generator) = cairo_claim_generator.write_trace(None);
     tree_builder.extend_evals(trace_evals);
     tree_builder.finalize_interaction();
 

--- a/stwo_cairo_prover/crates/prover/src/prover.rs
+++ b/stwo_cairo_prover/crates/prover/src/prover.rs
@@ -88,6 +88,7 @@ where
         preprocessed_trace: preprocessed_trace_variant,
         store_polynomials_coefficients,
         include_all_preprocessed_columns: _,
+        opt_n_id_to_big_components,
     } = prover_params;
 
     let span = span!(Level::INFO, "Write Preprocessed trace").entered();
@@ -98,7 +99,8 @@ where
     let cairo_claim_generator = create_cairo_claim_generator(input, preprocessed_trace.clone());
     // Base trace.
     let span = span!(Level::INFO, "Write Base trace").entered();
-    let (trace_evals, claim, interaction_generator) = cairo_claim_generator.write_trace();
+    let (trace_evals, claim, interaction_generator) =
+        cairo_claim_generator.write_trace(opt_n_id_to_big_components);
     span.exit();
 
     // The maximal log trace size (without blowup factor) is the maximum over preprocessed trace
@@ -178,7 +180,8 @@ where
     let cairo_claim_generator = create_cairo_claim_generator(input, preprocessed_trace.clone());
     // Base trace.
     let span = span!(Level::INFO, "Write Base trace").entered();
-    let (trace_evals, claim, interaction_generator) = cairo_claim_generator.write_trace();
+    let (trace_evals, claim, interaction_generator) =
+        cairo_claim_generator.write_trace(prover_params.opt_n_id_to_big_components);
     span.exit();
 
     prove_cairo_common::<MC>(
@@ -213,6 +216,7 @@ where
         preprocessed_trace: preprocessed_trace_variant,
         store_polynomials_coefficients,
         include_all_preprocessed_columns,
+        opt_n_id_to_big_components: _,
     } = prover_params;
 
     // Setup protocol.
@@ -334,6 +338,10 @@ pub struct ProverParameters {
     /// Whether to include samples for every preprocessed column in the proof. Default is `false`.
     /// If `false`, the proof only includes samples for columns used by at least one component.
     pub include_all_preprocessed_columns: bool,
+
+    /// Optional number of components for the memory id to big claim.
+    /// If not provided, the number of components will be inferred from the input.
+    pub opt_n_id_to_big_components: Option<usize>,
 }
 
 /// The hash function used for commitments, for the prover-verifier channel,
@@ -387,6 +395,7 @@ pub fn create_and_serialize_proof(
             preprocessed_trace: PreProcessedTraceVariant::Canonical,
             store_polynomials_coefficients: false,
             include_all_preprocessed_columns: false,
+            opt_n_id_to_big_components: None,
         }
     };
 
@@ -512,6 +521,7 @@ pub mod tests {
                 channel_salt: 42,
                 store_polynomials_coefficients: false,
                 include_all_preprocessed_columns: false,
+                opt_n_id_to_big_components: None,
             };
             let cairo_proof =
                 prove_cairo::<Poseidon252MerkleChannel>(input, prover_params).unwrap();
@@ -627,6 +637,7 @@ pub mod tests {
                 channel_salt: 0,
                 store_polynomials_coefficients: true,
                 include_all_preprocessed_columns: false,
+                opt_n_id_to_big_components: None,
             };
             let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, prover_params).unwrap();
             verify_cairo::<Blake2sMerkleChannel>(cairo_proof.into()).unwrap();
@@ -654,6 +665,7 @@ pub mod tests {
                 channel_salt: 0,
                 store_polynomials_coefficients: false,
                 include_all_preprocessed_columns: false,
+                opt_n_id_to_big_components: None,
             };
             let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, prover_params).unwrap();
             let mut proof_file = NamedTempFile::new().unwrap();
@@ -723,6 +735,7 @@ pub mod tests {
                 channel_salt: 0,
                 store_polynomials_coefficients: false,
                 include_all_preprocessed_columns: false,
+                opt_n_id_to_big_components: None,
             };
             let cairo_proof = prove_cairo::<Blake2sMerkleChannel>(input, prover_params).unwrap();
             let mut proof_file = NamedTempFile::new().unwrap();
@@ -769,6 +782,7 @@ pub mod tests {
                 channel_salt: 0,
                 store_polynomials_coefficients: false,
                 include_all_preprocessed_columns: false,
+                opt_n_id_to_big_components: None,
             };
             let proofs = (0..n_proofs_to_compare)
                 .map(|_| {
@@ -838,6 +852,7 @@ pub mod tests {
                     channel_salt: 0,
                     store_polynomials_coefficients: false,
                     include_all_preprocessed_columns: false,
+                    opt_n_id_to_big_components: None,
                 };
                 let cairo_proof =
                     prove_cairo::<Blake2sMerkleChannel>(input, prover_params).unwrap();
@@ -862,6 +877,7 @@ pub mod tests {
                     channel_salt: 0,
                     store_polynomials_coefficients: false,
                     include_all_preprocessed_columns: false,
+                    opt_n_id_to_big_components: None,
                 };
                 let cairo_proof =
                     prove_cairo::<Blake2sMerkleChannel>(input, prover_params).unwrap();
@@ -994,6 +1010,7 @@ pub mod tests {
                     channel_salt: 0,
                     store_polynomials_coefficients: false,
                     include_all_preprocessed_columns: false,
+                    opt_n_id_to_big_components: None,
                 };
 
                 // Run poseidon builtin with 15 different instances.
@@ -1064,6 +1081,7 @@ pub mod tests {
                     channel_salt: 0,
                     store_polynomials_coefficients: false,
                     include_all_preprocessed_columns: false,
+                    opt_n_id_to_big_components: None,
                 };
 
                 // Run pedersen builtin with 15 different instances.

--- a/stwo_cairo_prover/crates/prover/src/witness/cairo_claim_generator.rs
+++ b/stwo_cairo_prover/crates/prover/src/witness/cairo_claim_generator.rs
@@ -720,6 +720,7 @@ impl CairoClaimGenerator {
 
     pub fn write_trace(
         self,
+        opt_n_id_to_big_components: Option<usize>,
     ) -> (
         Vec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>,
         CairoClaim,
@@ -1424,8 +1425,11 @@ impl CairoClaimGenerator {
             .memory_id_to_big
             .map(|gen| {
                 const LOG_MAX_BIG_SIZE: u32 = MAX_SEQUENCE_LOG_SIZE;
-                let (big_traces, small_trace, claim, interaction_gen) =
-                    gen.write_trace(self.range_check_9_9.as_ref().unwrap(), LOG_MAX_BIG_SIZE);
+                let (big_traces, small_trace, claim, interaction_gen) = gen.write_trace(
+                    self.range_check_9_9.as_ref().unwrap(),
+                    LOG_MAX_BIG_SIZE,
+                    opt_n_id_to_big_components,
+                );
                 for big_trace in big_traces {
                     evals.extend(big_trace);
                 }

--- a/stwo_cairo_prover/crates/prover/src/witness/components/memory_id_to_big.rs
+++ b/stwo_cairo_prover/crates/prover/src/witness/components/memory_id_to_big.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use cairo_air::components::memory_id_to_big::{
     Claim as BigClaim, InteractionClaim as BigInteractionClaim, MEMORY_ID_SIZE,
+    N_MULTIPLICITY_COLUMNS,
 };
 use cairo_air::components::memory_id_to_small::{
     Claim as SmallClaim, InteractionClaim as SmallInteractionClaim,
@@ -107,6 +108,7 @@ impl ClaimGenerator {
         self,
         range_check_9_9_trace_generator: &range_check_9_9::ClaimGenerator,
         log_max_big_size: u32,
+        opt_n_components: Option<usize>,
     ) -> (
         BigTraces,
         SmallTrace,
@@ -117,6 +119,7 @@ impl ClaimGenerator {
             self.big_values,
             self.big_mults.into_simd_vec(),
             log_max_big_size,
+            opt_n_components,
         );
         let small_table_trace =
             gen_small_memory_trace(self.small_values, self.small_mults.into_simd_vec());
@@ -296,10 +299,12 @@ impl AddInputs for ClaimGenerator {
 
 /// Generates the trace for the id -> f252 `big` tables. Splits the table to multiple traces
 /// according to `log_max_big_size`.
+/// If `opt_n_components` is provided, the function will pad the traces to the number of components.
 fn gen_big_memory_traces(
     values: Vec<[u32; 8]>,
     mults: Vec<PackedM31>,
     log_max_big_size: u32,
+    opt_n_components: Option<usize>,
 ) -> Vec<Vec<BaseColumn>> {
     assert!(log_max_big_size >= LOG_N_LANES);
     let max_big_size = 1 << log_max_big_size;
@@ -312,6 +317,19 @@ fn gen_big_memory_traces(
     {
         let trace = gen_single_big_memory_trace(values, mults);
         traces.push(trace);
+    }
+
+    if let Some(n_components) = opt_n_components {
+        assert!(n_components >= traces.len());
+
+        let min_trace_length = N_LANES;
+        for _ in traces.len()..n_components {
+            traces.push(
+                std::iter::repeat_with(|| BaseColumn::zeros(min_trace_length))
+                    .take(FELT252_N_WORDS + N_MULTIPLICITY_COLUMNS)
+                    .collect_vec(),
+            );
+        }
     }
 
     traces
@@ -687,7 +705,7 @@ mod tests {
         let id_to_big = super::ClaimGenerator::new(Arc::clone(&memory));
         let range_check_9_9 = range_check_9_9::ClaimGenerator::new(Arc::clone(&preprocessed_trace));
         let (big_traces, small_trace, (big_claim, small_claim), interaction_generator) =
-            id_to_big.write_trace(&range_check_9_9, log_max_seq_size);
+            id_to_big.write_trace(&range_check_9_9, log_max_seq_size, None);
         for big_trace in big_traces {
             tree_builder.extend_evals(big_trace);
         }
@@ -763,7 +781,7 @@ mod tests {
             vec![expected_first_big_log_size, expected_second_big_log_size];
 
         let (_, _, (big_claim, small_claim), _) =
-            id_to_big.write_trace(&range_check_9_9, log_max_seq_size);
+            id_to_big.write_trace(&range_check_9_9, log_max_seq_size, None);
 
         assert_eq!(small_claim.log_size, expected_small_log_size);
         assert_eq!(big_claim.big_log_sizes, expected_big_log_sizes);


### PR DESCRIPTION
Pads memory_id_to_big big traces to a caller-specified count when provided, allowing the number of components to be fixed independently of the input size.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1754)
<!-- Reviewable:end -->
