### PR TITLE
circuit_air: add empty crate skeleton

### DIFF
--- a/stwo_cairo_verifier/Scarb.lock
+++ b/stwo_cairo_verifier/Scarb.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "stwo_circuit_air"
+version = "0.1.0"
+dependencies = [
+ "bounded_int",
+ "stwo_constraint_framework",
+ "stwo_verifier_core",
+]
+
+[[package]]
 name = "stwo_constraint_framework"
 version = "0.1.0"
 dependencies = [

--- a/stwo_cairo_verifier/Scarb.toml
+++ b/stwo_cairo_verifier/Scarb.toml
@@ -4,6 +4,7 @@ members = [
     "crates/cairo_air",
     "crates/cairo_verifier",
     "crates/cairo_verifier_mock",
+    "crates/circuit_air",
     "crates/constraint_framework",
     "crates/verifier_core",
     "crates/verifier_utils",

--- a/stwo_cairo_verifier/crates/circuit_air/Scarb.toml
+++ b/stwo_cairo_verifier/crates/circuit_air/Scarb.toml
@@ -1,0 +1,26 @@
+[package]
+name = "stwo_circuit_air"
+version = "0.1.0"
+edition = "2024_07"
+
+[lib]
+casm = true
+
+[features]
+poseidon252_verifier = ["stwo_verifier_core/poseidon252_verifier"]
+qm31_opcode = ["stwo_verifier_core/qm31_opcode"]
+
+
+[tool.fmt]
+sort-module-level-items = true
+
+[tool]
+cairo-lint.workspace = true
+
+[dependencies]
+bounded_int = { path = "../bounded_int" }
+stwo_verifier_core = { path = "../verifier_core" }
+stwo_constraint_framework = { path = "../constraint_framework" }
+
+[dev-dependencies]
+cairo_test = "2.12.2"

--- a/stwo_cairo_verifier/crates/circuit_air/src/lib.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/lib.cairo
@@ -1,0 +1,1 @@
+//! `stwo_circuit_air`: AIR-specific verifier-side logic written in Cairo for the stwo-circuits circuit.


### PR DESCRIPTION
New `stwo_circuit_air` crate with workspace registration. Body of
`lib.cairo` is intentionally empty — added in subsequent PRs (component
stubs, claims aggregator, `CircuitAir`, `verify_circuit` entry point).
Mirrors the role of `stwo_cairo_air` but for the stwo-circuits circuit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1755)
<!-- Reviewable:end -->
