### PR TITLE
Add diff-scoped test selection for PR run-tests job

### DIFF
--- a/.github/workflows/cairo-ci.yaml
+++ b/.github/workflows/cairo-ci.yaml
@@ -155,6 +155,8 @@ jobs:
         working-directory: ./stwo_cairo_prover
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential
       - name: Install Rust toolchain
@@ -168,8 +170,16 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: stwo_cairo_prover
-      - run: cargo nextest run --cargo-profile witness-opt-1 --features=slow-tests -j ${{ env.NEXTTEST_THREADS }} -P ci
-      - run: cargo nextest run --cargo-profile witness-opt-1 --features=extract-mem-trace test_serialize_deserialize_mem_trace -j ${{ env.NEXTTEST_THREADS }} -P ci
+      - name: Run nextest (PR — diff-scoped)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+        run: scripts/test_changed.py
+      - name: Run nextest (full)
+        if: github.event_name != 'pull_request'
+        run: |
+          cargo nextest run --cargo-profile witness-opt-1 --features=slow-tests -j ${{ env.NEXTTEST_THREADS }} -P ci
+          cargo nextest run --cargo-profile witness-opt-1 --features=extract-mem-trace test_serialize_deserialize_mem_trace -j ${{ env.NEXTTEST_THREADS }} -P ci
 
   cairo-prover-wasm:
     runs-on: ubuntu-latest

--- a/stwo_cairo_prover/scripts/test_changed.py
+++ b/stwo_cairo_prover/scripts/test_changed.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Run cargo nextest scoped to crates (transitively) impacted by the diff
+between HEAD and BASE_REF. Falls back to the full suite when changes touch
+files outside the safe selection scope.
+
+Usage:
+    BASE_REF=origin/main scripts/test_changed.py
+    DRY_RUN=1 BASE_REF=origin/main scripts/test_changed.py   # print only
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SAFETY_NET_EXACT = {
+    "stwo_cairo_prover/Cargo.lock",
+    "stwo_cairo_prover/rust-toolchain.toml",
+    "stwo_cairo_prover/Cargo.toml",
+    "stwo_cairo_prover/.config/nextest.toml",
+}
+
+SAFETY_NET_PREFIXES = (
+    "stwo_cairo_prover/scripts/",
+    "stwo_cairo_prover/test_data/",
+    ".github/workflows/",
+)
+
+SLOW_TESTS_CMD = [
+    "cargo", "nextest", "run",
+    "--cargo-profile", "witness-opt-1",
+    "--features=slow-tests",
+    "-j", "1",
+    "-P", "ci",
+]
+
+EXTRACT_MEM_TRACE_CMD = [
+    "cargo", "nextest", "run",
+    "--cargo-profile", "witness-opt-1",
+    "--features=extract-mem-trace",
+    "test_serialize_deserialize_mem_trace",
+    "-j", "1",
+    "-P", "ci",
+]
+
+FULL_NEXTEST_CMDS = [SLOW_TESTS_CMD, EXTRACT_MEM_TRACE_CMD]
+
+
+def log(msg: str) -> None:
+    print(f"test_changed.py: {msg}", file=sys.stderr)
+
+
+def run_cmds(cmds: list[list[str]], dry_run: bool, cwd: Path) -> None:
+    for cmd in cmds:
+        print("+ " + " ".join(cmd), file=sys.stderr)
+        if not dry_run:
+            subprocess.run(cmd, check=True, cwd=cwd)
+
+
+def run_full_suite(reason: str, dry_run: bool, prover_dir: Path) -> None:
+    log(f"running full nextest suite (reason: {reason}).")
+    run_cmds(FULL_NEXTEST_CMDS, dry_run, prover_dir)
+
+
+def run_filtered_suite(filter_expr: str, dry_run: bool, prover_dir: Path) -> None:
+    log(f"filter expression: {filter_expr}")
+    cmds = [cmd + ["-E", filter_expr] for cmd in FULL_NEXTEST_CMDS]
+    run_cmds(cmds, dry_run, prover_dir)
+
+
+def workspace_packages(prover_dir: Path, repo_root: Path) -> list[tuple[str, str]]:
+    """Return [(package_dir_relative_to_repo_root_with_trailing_slash, pkg_name), ...]
+    sorted longest-prefix-first so the deepest-matching package wins."""
+    metadata_json = subprocess.check_output(
+        ["cargo", "metadata", "--no-deps", "--format-version=1"],
+        text=True,
+        cwd=prover_dir,
+    )
+    metadata = json.loads(metadata_json)
+    pkg_dirs: list[tuple[str, str]] = []
+    for pkg in metadata["packages"]:
+        manifest = Path(pkg["manifest_path"])
+        try:
+            rel_dir = manifest.parent.relative_to(repo_root)
+        except ValueError:
+            continue
+        pkg_dirs.append((f"{rel_dir.as_posix()}/", pkg["name"]))
+    pkg_dirs.sort(key=lambda x: -len(x[0]))
+    return pkg_dirs
+
+
+def main() -> None:
+    base_ref = os.environ.get("BASE_REF", "origin/main")
+    dry_run = bool(os.environ.get("DRY_RUN"))
+
+    repo_root = Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"], text=True
+        ).strip()
+    )
+    prover_dir = repo_root / "stwo_cairo_prover"
+
+    try:
+        base = subprocess.check_output(
+            ["git", "merge-base", "HEAD", base_ref],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            cwd=repo_root,
+        ).strip()
+    except subprocess.CalledProcessError:
+        run_full_suite(
+            f"cannot resolve merge-base against {base_ref}", dry_run, prover_dir
+        )
+        return
+
+    changed = [
+        line
+        for line in subprocess.check_output(
+            ["git", "diff", "--name-only", base, "HEAD"],
+            text=True,
+            cwd=repo_root,
+        ).splitlines()
+        if line
+    ]
+
+    if not changed:
+        log(f"no changes vs {base_ref}; nothing to run.")
+        return
+
+    for f in changed:
+        if f in SAFETY_NET_EXACT or any(f.startswith(p) for p in SAFETY_NET_PREFIXES):
+            run_full_suite(f"safety-net: {f}", dry_run, prover_dir)
+            return
+
+    pkg_dirs = workspace_packages(prover_dir, repo_root)
+    pkgs: set[str] = set()
+    for f in changed:
+        if not f.startswith("stwo_cairo_prover/"):
+            continue
+        for dir_prefix, name in pkg_dirs:
+            if f.startswith(dir_prefix):
+                pkgs.add(name)
+                break
+
+    if not pkgs:
+        log("no Rust crate impact detected; nothing to run.")
+        return
+
+    filter_expr = " + ".join(f"rdeps({n})" for n in sorted(pkgs))
+    run_filtered_suite(filter_expr, dry_run, prover_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `stwo_cairo_prover/scripts/test_changed.py`: maps the diff against `BASE_REF` (default `origin/main`) to impacted workspace crates via `cargo metadata --no-deps`, then invokes `cargo nextest run` with `-E 'rdeps(c1) + rdeps(c2) + …'`. A safety-net (Cargo.lock, rust-toolchain.toml, workspace Cargo.toml, .config/nextest.toml, scripts/, test_data/, .github/workflows/, or unresolved merge-base) forces a full run.
- Wires the script into the `run-tests` CI job on `pull_request` only. `merge_group` and `push` to `main` keep the original two full-suite `cargo nextest run` invocations unchanged. Bumps the run-tests checkout to `fetch-depth: 0` so `git merge-base` can resolve.
- Honors `DRY_RUN=1` for echoing planned commands without execution. Identical stderr fingerprints to a hand-written reference, so it's easy to script around in future.

## Why

Crate-level test selection avoids running the full nextest suite for every PR. Soundness preservation is built in via the safety-net (false-positive full runs are cheap; false-negative misses are not), and the merge-queue / `main` branch always run the full suite.

## Test plan

- [x] DRY_RUN no-op (no changes vs HEAD)
- [x] DRY_RUN single-crate (utils)
- [x] DRY_RUN multi-crate (utils + common, alphabetically sorted in filter)
- [x] DRY_RUN safety-net (Cargo.lock → full run)
- [x] DRY_RUN docs-only (README → nothing to run)
- [ ] CI run on this PR validates `cargo nextest -E 'rdeps(...)'` end-to-end (first real-run validation; `cargo-nextest` was unavailable locally for the dev verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1760)
<!-- Reviewable:end -->
