### PR TITLE
Surface N_INTERACTION_COLUMNS in components

### DIFF
--- a/stwo_cairo_prover/crates/common/casm_registry.json
+++ b/stwo_cairo_prover/crates/common/casm_registry.json
@@ -1,5 +1,5 @@
 {
-  "air_version": "bd0c7c1a",
+  "air_version": "73508f8d",
   "canonical_ppt_n_trace_cells": 543100528,
   "canonical_without_pedersen_ppt_n_trace_cells": 73338480,
   "canonical_small_ppt_n_trace_cells": 10161776,

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/add_ap_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/add_ap_opcode.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::read_small::read_small_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 17;
+pub const N_INTERACTION_COLUMNS: usize = 16;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 6] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 1), ('MemoryIdToBig', 1), ('RangeCheck_18', 1),
     ('RangeCheck_11', 1), ('Opcodes', 1),
@@ -21,7 +22,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 16].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/add_mod_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/add_mod_builtin.cairo
@@ -4,6 +4,7 @@ use crate::components::subroutines::mod_utils::mod_utils_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 267;
+pub const N_INTERACTION_COLUMNS: usize = 108;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 2] = [
     ('MemoryAddressToId', 29), ('MemoryIdToBig', 24),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 108].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/add_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/add_opcode.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::verify_add_252::verify_add_252_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 103;
+pub const N_INTERACTION_COLUMNS: usize = 20;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 3), ('MemoryIdToBig', 3), ('Opcodes', 1),
 ];
@@ -20,7 +21,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 20].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/add_opcode_small.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/add_opcode_small.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::read_small::read_small_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 39;
+pub const N_INTERACTION_COLUMNS: usize = 20;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 3), ('MemoryIdToBig', 3), ('Opcodes', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 20].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/assert_eq_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/assert_eq_opcode.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::mem_verify_equal::mem_verify_equal_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 12;
+pub const N_INTERACTION_COLUMNS: usize = 12;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 3] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 2), ('Opcodes', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 12].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/assert_eq_opcode_double_deref.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/assert_eq_opcode_double_deref.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::read_positive_num_bits_29::read_positive_num
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 19;
+pub const N_INTERACTION_COLUMNS: usize = 16;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 3), ('MemoryIdToBig', 1), ('Opcodes', 1),
 ];
@@ -20,7 +21,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 16].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/assert_eq_opcode_imm.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/assert_eq_opcode_imm.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::mem_verify_equal::mem_verify_equal_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 9;
+pub const N_INTERACTION_COLUMNS: usize = 12;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 3] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 2), ('Opcodes', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 12].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/bitwise_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/bitwise_builtin.cairo
@@ -7,6 +7,7 @@ use crate::components::subroutines::read_positive_num_bits_252::read_positive_nu
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 89;
+pub const N_INTERACTION_COLUMNS: usize = 76;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('MemoryAddressToId', 5), ('MemoryIdToBig', 5), ('VerifyBitwiseXor_9', 27),
     ('VerifyBitwiseXor_8', 1),
@@ -23,7 +24,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 76].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/blake_compress_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/blake_compress_opcode.cairo
@@ -7,6 +7,7 @@ use crate::components::subroutines::verify_u_32::verify_u_32_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 174;
+pub const N_INTERACTION_COLUMNS: usize = 148;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 8] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 20), ('MemoryIdToBig', 20),
     ('RangeCheck_7_2_5', 17), ('VerifyBitwiseXor_8', 4), ('BlakeRound', 1), ('TripleXor32', 8),
@@ -23,7 +24,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 148].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/blake_g.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/blake_g.cairo
@@ -8,6 +8,7 @@ use crate::components::subroutines::xor_rot_32_r_8::xor_rot_32_r_8_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 53;
+pub const N_INTERACTION_COLUMNS: usize = 36;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 6] = [
     ('VerifyBitwiseXor_8', 4), ('VerifyBitwiseXor_8_B', 4), ('VerifyBitwiseXor_12', 2),
     ('VerifyBitwiseXor_4', 2), ('VerifyBitwiseXor_7', 2), ('VerifyBitwiseXor_9', 2),
@@ -23,7 +24,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 36].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/blake_round.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/blake_round.cairo
@@ -4,6 +4,7 @@ use crate::components::subroutines::read_u_32::read_u_32_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 212;
+pub const N_INTERACTION_COLUMNS: usize = 120;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 6] = [
     ('BlakeRoundSigma', 1), ('RangeCheck_7_2_5', 16), ('MemoryAddressToId', 16),
     ('MemoryIdToBig', 16), ('BlakeG', 8), ('BlakeRound', 1),
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 120].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/blake_round_sigma.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/blake_round_sigma.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 4;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/call_opcode_abs.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/call_opcode_abs.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::read_positive_num_bits_29::read_positive_num
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 25;
+pub const N_INTERACTION_COLUMNS: usize = 20;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 3), ('MemoryIdToBig', 3), ('Opcodes', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 20].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/call_opcode_rel_imm.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/call_opcode_rel_imm.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::read_small::read_small_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 24;
+pub const N_INTERACTION_COLUMNS: usize = 20;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 3), ('MemoryIdToBig', 3), ('Opcodes', 1),
 ];
@@ -20,7 +21,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 20].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/ec_op_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/ec_op_builtin.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::verify_reduced_252::verify_reduced_252_evalu
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 273;
+pub const N_INTERACTION_COLUMNS: usize = 36;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('MemoryAddressToId', 7), ('MemoryIdToBig', 7), ('RangeCheck_8', 2), ('PartialEcMulGeneric', 1),
 ];
@@ -21,7 +22,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 36].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/generic_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/generic_opcode.cairo
@@ -7,6 +7,7 @@ use crate::components::subroutines::update_registers::update_registers_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 243;
+pub const N_INTERACTION_COLUMNS: usize = 136;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 22] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 3), ('MemoryIdToBig', 3), ('RangeCheck_9_9', 4),
     ('RangeCheck_9_9_B', 4), ('RangeCheck_9_9_C', 4), ('RangeCheck_9_9_D', 4),
@@ -26,7 +27,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 136].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/jnz_opcode_non_taken.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/jnz_opcode_non_taken.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::mem_verify::mem_verify_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 9;
+pub const N_INTERACTION_COLUMNS: usize = 12;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 1), ('MemoryIdToBig', 1), ('Opcodes', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 12].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/jnz_opcode_taken.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/jnz_opcode_taken.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::read_small::read_small_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 47;
+pub const N_INTERACTION_COLUMNS: usize = 16;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 2), ('MemoryIdToBig', 2), ('Opcodes', 1),
 ];
@@ -20,7 +21,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 16].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_abs.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_abs.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::read_positive_num_bits_29::read_positive_num
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 14;
+pub const N_INTERACTION_COLUMNS: usize = 12;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 1), ('MemoryIdToBig', 1), ('Opcodes', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 12].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_double_deref.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_double_deref.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::read_positive_num_bits_29::read_positive_num
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 21;
+pub const N_INTERACTION_COLUMNS: usize = 16;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 2), ('MemoryIdToBig', 2), ('Opcodes', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 16].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_rel.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_rel.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::read_small::read_small_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 16;
+pub const N_INTERACTION_COLUMNS: usize = 12;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 1), ('MemoryIdToBig', 1), ('Opcodes', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 12].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_rel_imm.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/jump_opcode_rel_imm.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::read_small::read_small_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 13;
+pub const N_INTERACTION_COLUMNS: usize = 12;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 1), ('MemoryIdToBig', 1), ('Opcodes', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 12].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/memory_id_to_small.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/memory_id_to_small.cairo
@@ -4,6 +4,7 @@ use crate::components::subroutines::range_check_mem_value_n_8::range_check_mem_v
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 9;
+pub const N_INTERACTION_COLUMNS: usize = 12;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('RangeCheck_9_9', 1), ('RangeCheck_9_9_B', 1), ('RangeCheck_9_9_C', 1),
     ('RangeCheck_9_9_D', 1),
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 12].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/mul_mod_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/mul_mod_builtin.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::mod_words_to_12_bit_array::mod_words_to_12_b
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 426;
+pub const N_INTERACTION_COLUMNS: usize = 376;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 5] = [
     ('MemoryAddressToId', 29), ('MemoryIdToBig', 24), ('RangeCheck_12', 32),
     ('RangeCheck_3_6_6_3', 40), ('RangeCheck_18', 62),
@@ -22,7 +23,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 376].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/mul_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/mul_opcode.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::verify_mul_252::verify_mul_252_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 130;
+pub const N_INTERACTION_COLUMNS: usize = 76;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 12] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 3), ('MemoryIdToBig', 3), ('RangeCheck_20', 4),
     ('RangeCheck_20_B', 4), ('RangeCheck_20_C', 4), ('RangeCheck_20_D', 4), ('RangeCheck_20_E', 3),
@@ -22,7 +23,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 76].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/mul_opcode_small.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/mul_opcode_small.cairo
@@ -7,6 +7,7 @@ use crate::components::subroutines::verify_mul_small::verify_mul_small_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 37;
+pub const N_INTERACTION_COLUMNS: usize = 24;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 5] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 3), ('MemoryIdToBig', 3), ('RangeCheck_11', 3),
     ('Opcodes', 1),
@@ -22,7 +23,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 24].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/partial_ec_mul_generic.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/partial_ec_mul_generic.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::verify_reduced_252::verify_reduced_252_evalu
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 624;
+pub const N_INTERACTION_COLUMNS: usize = 628;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 18] = [
     ('RangeCheck_8', 4), ('RangeCheck_9_9', 16), ('RangeCheck_9_9_B', 16), ('RangeCheck_9_9_C', 16),
     ('RangeCheck_9_9_D', 16), ('RangeCheck_9_9_E', 16), ('RangeCheck_9_9_F', 16),
@@ -25,7 +26,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 628].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/partial_ec_mul_window_bits_18.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/partial_ec_mul_window_bits_18.cairo
@@ -4,6 +4,7 @@ use crate::components::subroutines::ec_add::ec_add_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 297;
+pub const N_INTERACTION_COLUMNS: usize = 260;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 18] = [
     ('PedersenPointsTableWindowBits18', 1), ('RangeCheck_9_9', 6), ('RangeCheck_9_9_B', 6),
     ('RangeCheck_9_9_C', 6), ('RangeCheck_9_9_D', 6), ('RangeCheck_9_9_E', 6),
@@ -23,7 +24,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 260].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/partial_ec_mul_window_bits_9.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/partial_ec_mul_window_bits_9.cairo
@@ -4,6 +4,7 @@ use crate::components::subroutines::ec_add::ec_add_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 311;
+pub const N_INTERACTION_COLUMNS: usize = 260;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 18] = [
     ('PedersenPointsTableWindowBits9', 1), ('RangeCheck_9_9', 6), ('RangeCheck_9_9_B', 6),
     ('RangeCheck_9_9_C', 6), ('RangeCheck_9_9_D', 6), ('RangeCheck_9_9_E', 6),
@@ -23,7 +24,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 260].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_aggregator_window_bits_18.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_aggregator_window_bits_18.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::verify_reduced_252::verify_reduced_252_evalu
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 206;
+pub const N_INTERACTION_COLUMNS: usize = 24;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 3] = [
     ('MemoryIdToBig', 3), ('RangeCheck_8', 4), ('PartialEcMulWindowBits18', 2),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 24].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_aggregator_window_bits_9.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_aggregator_window_bits_9.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::verify_reduced_252::verify_reduced_252_evalu
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 234;
+pub const N_INTERACTION_COLUMNS: usize = 24;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 3] = [
     ('MemoryIdToBig', 3), ('RangeCheck_8', 4), ('PartialEcMulWindowBits9', 2),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 24].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_builtin.cairo
@@ -4,6 +4,7 @@ use crate::components::subroutines::read_id::read_id_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 3;
+pub const N_INTERACTION_COLUMNS: usize = 8;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 2] = [
     ('MemoryAddressToId', 3), ('PedersenAggregatorWindowBits18', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 8].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_builtin_narrow_windows.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_builtin_narrow_windows.cairo
@@ -4,6 +4,7 @@ use crate::components::subroutines::read_id::read_id_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 3;
+pub const N_INTERACTION_COLUMNS: usize = 8;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 2] = [
     ('MemoryAddressToId', 3), ('PedersenAggregatorWindowBits9', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 8].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_points_table_window_bits_18.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/pedersen_points_table_window_bits_18.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 23;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_3_partial_rounds_chain.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_3_partial_rounds_chain.cairo
@@ -4,6 +4,7 @@ use crate::components::subroutines::poseidon_partial_round::poseidon_partial_rou
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 169;
+pub const N_INTERACTION_COLUMNS: usize = 36;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 6] = [
     ('PoseidonRoundKeys', 1), ('Cube252', 3), ('RangeCheck_4_4_4_4', 6), ('RangeCheck_4_4', 3),
     ('RangeCheck252Width27', 3), ('Poseidon3PartialRoundsChain', 1),
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 36].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_builtin.cairo
@@ -4,6 +4,7 @@ use crate::components::subroutines::read_id::read_id_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 6;
+pub const N_INTERACTION_COLUMNS: usize = 16;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 2] = [
     ('MemoryAddressToId', 6), ('PoseidonAggregator', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 16].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_full_round_chain.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_full_round_chain.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::linear_combination_n_4_coefs_3_1_1_1::linear
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 126;
+pub const N_INTERACTION_COLUMNS: usize = 24;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('Cube252', 3), ('PoseidonRoundKeys', 1), ('RangeCheck_3_3_3_3_3', 6),
     ('PoseidonFullRoundChain', 1),
@@ -21,7 +22,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 24].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_round_keys.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/poseidon_round_keys.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 6;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/qm_31_add_mul_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/qm_31_add_mul_opcode.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::qm_31_read_reduced::qm_31_read_reduced_evalu
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 73;
+pub const N_INTERACTION_COLUMNS: usize = 24;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 5] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 3), ('MemoryIdToBig', 3),
     ('RangeCheck_4_4_4_4', 3), ('Opcodes', 1),
@@ -20,7 +21,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 24].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check96_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check96_builtin.cairo
@@ -4,6 +4,7 @@ use crate::components::subroutines::read_positive_num_bits_96::read_positive_num
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 12;
+pub const N_INTERACTION_COLUMNS: usize = 8;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 3] = [
     ('MemoryAddressToId', 1), ('RangeCheck_6', 1), ('MemoryIdToBig', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 8].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_11.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_11.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 11;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_12.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_12.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 12;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_18.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_18.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 2;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 18;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_20.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_20.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 8;
+pub const N_INTERACTION_COLUMNS: usize = 16;
 pub const LOG_SIZE: u32 = 20;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 16].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_252_width_27.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_252_width_27.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 20;
+pub const N_INTERACTION_COLUMNS: usize = 32;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 7] = [
     ('RangeCheck_9_9', 1), ('RangeCheck_18', 7), ('RangeCheck_9_9_B', 1), ('RangeCheck_18_B', 2),
     ('RangeCheck_9_9_C', 1), ('RangeCheck_9_9_D', 1), ('RangeCheck_9_9_E', 1),
@@ -18,7 +19,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 32].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_3_3_3_3_3.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_3_3_3_3_3.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 15;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_3_6_6_3.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_3_6_6_3.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 18;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_4_3.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_4_3.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 7;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_4_4.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_4_4.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 8;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_4_4_4_4.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_4_4_4_4.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 16;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_6.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_6.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 6;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_7_2_5.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_7_2_5.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 14;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_8.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_8.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 8;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_9_9.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_9_9.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 8;
+pub const N_INTERACTION_COLUMNS: usize = 16;
 pub const LOG_SIZE: u32 = 18;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 16].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_builtin.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/range_check_builtin.cairo
@@ -4,6 +4,7 @@ use crate::components::subroutines::read_positive_num_bits_128::read_positive_nu
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 17;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 2] = [
     ('MemoryAddressToId', 1), ('MemoryIdToBig', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/ret_opcode.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/ret_opcode.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::read_positive_num_bits_29::read_positive_num
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 16;
+pub const N_INTERACTION_COLUMNS: usize = 16;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('VerifyInstruction', 1), ('MemoryAddressToId', 2), ('MemoryIdToBig', 2), ('Opcodes', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 16].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/sample_evaluations.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/sample_evaluations.cairo
@@ -1,4 +1,4 @@
-// AIR version bd0c7c1a
+// AIR version 73508f8d
 use stwo_verifier_core::fields::m31::M31;
 pub const ADD_AP_OPCODE_SAMPLE_EVAL_RESULT: [M31; 4] = [
     M31 { inner: 1435814162 }, M31 { inner: 1618992457 }, M31 { inner: 840348268 },

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/triple_xor_32.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/triple_xor_32.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::split_16_low_part_size_8::split_16_low_part_
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 21;
+pub const N_INTERACTION_COLUMNS: usize = 20;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 2] = [
     ('VerifyBitwiseXor_8', 4), ('VerifyBitwiseXor_8_B', 4),
 ];
@@ -20,7 +21,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 20].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_4.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_4.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 8;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_7.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_7.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 14;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_8.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_8.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 2;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 16;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_9.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/verify_bitwise_xor_9.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 18;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/cairo_air/src/components/verify_instruction.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/verify_instruction.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::mem_verify::mem_verify_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 17;
+pub const N_INTERACTION_COLUMNS: usize = 12;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('RangeCheck_7_2_5', 1), ('RangeCheck_4_3', 1), ('MemoryAddressToId', 1), ('MemoryIdToBig', 1),
 ];
@@ -19,7 +20,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 12].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/blake_g.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/blake_g.cairo
@@ -8,6 +8,7 @@ use crate::components::subroutines::xor_rot_32_r_8::xor_rot_32_r_8_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 53;
+pub const N_INTERACTION_COLUMNS: usize = 36;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 6] = [
     ('VerifyBitwiseXor_8', 4), ('VerifyBitwiseXor_8_B', 4), ('VerifyBitwiseXor_12', 2),
     ('VerifyBitwiseXor_4', 2), ('VerifyBitwiseXor_7', 2), ('VerifyBitwiseXor_9', 2),
@@ -23,7 +24,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 36].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/blake_g_gate.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/blake_g_gate.cairo
@@ -9,6 +9,7 @@ use crate::components::subroutines::xor_rot_32_r_16::xor_rot_32_r_16_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 52;
+pub const N_INTERACTION_COLUMNS: usize = 52;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 7] = [
     ('VerifyBitwiseXor_8', 6), ('VerifyBitwiseXor_8_B', 2), ('VerifyBitwiseXor_12', 2),
     ('VerifyBitwiseXor_4', 2), ('VerifyBitwiseXor_9', 2), ('VerifyBitwiseXor_7', 2), ('Gate', 6),
@@ -24,7 +25,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 52].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/blake_gate.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/blake_gate.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::qm_31_into_u_32::qm_31_into_u_32_evaluate;
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 151;
+pub const N_INTERACTION_COLUMNS: usize = 136;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 7] = [
     ('VerifyBitwiseXor_8', 4), ('RangeCheck_16', 16), ('RangeCheck_15', 16), ('BlakeRound', 1),
     ('TripleXor32', 8), ('BlakeOutput', 1), ('Gate', 4),
@@ -21,7 +22,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 136].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/blake_output.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/blake_output.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 24;
+pub const N_INTERACTION_COLUMNS: usize = 8;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 1] = [('BlakeOutput', 1)];
 
 #[derive(Drop, Serde, Copy)]
@@ -15,7 +16,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 8].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/blake_round.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/blake_round.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 148;
+pub const N_INTERACTION_COLUMNS: usize = 56;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 4] = [
     ('BlakeRoundSigma', 1), ('BlakeMessage', 16), ('BlakeG', 8), ('BlakeRound', 1),
 ];
@@ -17,7 +18,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 56].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/blake_round_sigma.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/blake_round_sigma.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 4;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/m_31_to_u_32.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/m_31_to_u_32.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 4;
+pub const N_INTERACTION_COLUMNS: usize = 12;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 2] = [('RangeCheck_16', 3), ('Gate', 1)];
 
 #[derive(Drop, Serde, Copy)]
@@ -15,7 +16,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 12].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/qm31_ops.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/qm31_ops.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 12;
+pub const N_INTERACTION_COLUMNS: usize = 8;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 1] = [('Gate', 2)];
 
 #[derive(Drop, Serde, Copy)]
@@ -15,7 +16,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 8].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/range_check_15.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/range_check_15.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 15;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/range_check_16.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/range_check_16.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 16;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/sample_evaluations.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/sample_evaluations.cairo
@@ -1,4 +1,4 @@
-// AIR version bd0c7c1a
+// AIR version 73508f8d
 use stwo_verifier_core::fields::m31::M31;
 pub const BLAKE_GATE_SAMPLE_EVAL_RESULT: [M31; 4] = [
     M31 { inner: 611602902 }, M31 { inner: 896180632 }, M31 { inner: 1988834866 },

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/triple_xor.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/triple_xor.cairo
@@ -5,6 +5,7 @@ use crate::components::subroutines::split_16_low_part_size_8::split_16_low_part_
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 20;
+pub const N_INTERACTION_COLUMNS: usize = 24;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 2] = [('VerifyBitwiseXor_8', 8), ('Gate', 3)];
 
 #[derive(Drop, Serde, Copy)]
@@ -17,7 +18,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 24].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/triple_xor_32.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/triple_xor_32.cairo
@@ -6,6 +6,7 @@ use crate::components::subroutines::split_16_low_part_size_8::split_16_low_part_
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 21;
+pub const N_INTERACTION_COLUMNS: usize = 20;
 pub const RELATION_USES_PER_ROW: [(felt252, u32); 2] = [
     ('VerifyBitwiseXor_8', 4), ('VerifyBitwiseXor_8_B', 4),
 ];
@@ -20,7 +21,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = *(self.log_size);
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 20].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/verify_bitwise_xor_12.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/verify_bitwise_xor_12.cairo
@@ -15,6 +15,7 @@ pub const LIMB_BITS: u32 = ELEM_BITS - EXPAND_BITS; // = 10
 pub const LOG_SIZE: u32 = (ELEM_BITS - EXPAND_BITS) * 2; // = 20
 pub const N_MULT_COLUMNS: usize = 16; // = 1 << (EXPAND_BITS * 2)
 pub const N_TRACE_COLUMNS: usize = N_MULT_COLUMNS;
+pub const N_INTERACTION_COLUMNS: usize = 32;
 
 /// `1 << LIMB_BITS = 1024`. Used as the offset shift between expansion bands.
 const LIMB_OFFSET: u32 = 1024;
@@ -28,7 +29,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
         // 8 pairs × QM31 (4 base columns each) = 32 interaction columns.
-        let interaction_log_sizes = [log_size; 32].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/verify_bitwise_xor_4.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/verify_bitwise_xor_4.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 8;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/verify_bitwise_xor_7.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/verify_bitwise_xor_7.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 14;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/verify_bitwise_xor_8.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/verify_bitwise_xor_8.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 2;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 16;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/components/verify_bitwise_xor_9.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/components/verify_bitwise_xor_9.cairo
@@ -3,6 +3,7 @@
 use crate::prelude::*;
 
 pub const N_TRACE_COLUMNS: usize = 1;
+pub const N_INTERACTION_COLUMNS: usize = 4;
 pub const LOG_SIZE: u32 = 18;
 
 #[derive(Drop, Serde, Copy)]
@@ -13,7 +14,7 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
         let log_size = LOG_SIZE;
         let preprocessed_log_sizes = array![log_size].span();
         let trace_log_sizes = [log_size; N_TRACE_COLUMNS].span();
-        let interaction_log_sizes = [log_size; 4].span();
+        let interaction_log_sizes = [log_size; N_INTERACTION_COLUMNS].span();
         array![preprocessed_log_sizes, trace_log_sizes, interaction_log_sizes]
     }
 


### PR DESCRIPTION
Add `pub const N_INTERACTION_COLUMNS: usize` to each component and use it
in the existing `interaction_log_sizes = [log_size; ..].span()` literal.
Pure refactor — the values are identical to the previous bare numbers.

This prepares the way for circuit_air's CircuitClaim to compute trace
shapes by walking per-component constants directly, without instantiating
ghost per-component Claim structs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1768)
<!-- Reviewable:end -->
