### PR TITLE
circuit_air: add CircuitAir type and Air impl

### DIFF
--- a/stwo_cairo_verifier/crates/cairo_air/src/cairo_air.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/cairo_air.cairo
@@ -29,18 +29,17 @@ pub mod poseidon_context_imports {
 }
 #[cfg(or(not(feature: "poseidon252_verifier"), feature: "poseidon_outputs_packing"))]
 use poseidon_context_imports::*;
-use stwo_cairo_air::preprocessed_columns::PREPROCESSED_COLUMN_LOG_SIZE;
 use stwo_cairo_air::range_checks::{RangeChecksComponents, RangeChecksComponentsImpl};
 use stwo_cairo_air::{PublicDataImpl, components};
 use stwo_constraint_framework::{
-    AirComponent, LookupElementsImpl, PreprocessedMaskValues, PreprocessedMaskValuesImpl,
+    AirComponent, LookupElementsImpl, PreprocessedMaskValuesImpl, validate_mask_usage,
 };
 use stwo_verifier_core::circle::CirclePoint;
 use stwo_verifier_core::fields::qm31::QM31;
 use stwo_verifier_core::pcs::verifier::CommitmentSchemeVerifierImpl;
 use stwo_verifier_core::utils::{ArrayImpl, OptionImpl, pow2};
 use stwo_verifier_core::verifier::Air;
-use stwo_verifier_core::{ColumnSpan, TreeArray, TreeSpan};
+use stwo_verifier_core::{ColumnSpan, TreeSpan};
 use crate::claim::{CairoInteractionClaim, CairoInteractionClaimImpl};
 use crate::claims::CairoClaim;
 
@@ -49,43 +48,6 @@ pub const MEMORY_ADDRESS_TO_ID_RELATION_ID: M31 = M31 { inner: 1444891767 };
 pub const MEMORY_ID_TO_VALUE_RELATION_ID: M31 = M31 { inner: 1662111297 };
 pub const VERIFY_BITWISE_XOR_12_RELATION_ID: M31 = M31 { inner: 648362599 };
 
-
-/// Validates that every `mask_value` provided in the proof (in `sampled_values`) is used by at
-/// least one component.
-///
-/// Since `eval_composition_polynomial_at_point` is responsible for validating the *structure*
-/// of `sampled_values` in the proof, it needs to ensure that all sampled preprocessed
-/// mask values are actually used. Otherwise, the prover would have the freedom to
-/// send a sample of a column even if it is unused, adding another term to the FRI quotients.
-///
-/// Additionally, there is a sanity check that the columns in the trace and interaction-trace were
-/// consumed by the components.
-/// This is not strictly necessary as the verifier generates the column indices on its own and only
-/// access samples of columns for which it knows about.
-fn validate_mask_usage(
-    preprocessed_mask_values: PreprocessedMaskValues,
-    trace_mask_values: ColumnSpan<Span<QM31>>,
-    interaction_trace_mask_values: ColumnSpan<Span<QM31>>,
-) {
-    preprocessed_mask_values.validate_usage();
-    assert!(trace_mask_values.is_empty());
-    assert!(interaction_trace_mask_values.is_empty());
-}
-
-/// Override the preprocessed trace log sizes, since they come from a global setting
-/// rather than computed by concatenating preprocessed log sizes of the individual
-/// components.
-/// TODO(ilya): consider removing the generation of `_invalid_preprocessed_trace_log_sizes`.
-pub fn override_preprocessed_trace_log_sizes(
-    aggregated_log_sizes: TreeArray<Span<u32>>,
-) -> TreeArray<Span<u32>> {
-    let boxed_triplet: Box<[Span<u32>; 3]> = *aggregated_log_sizes.span().try_into().unwrap();
-    let [_invalid_preprocessed_trace_log_sizes, trace_log_sizes, interaction_log_sizes] =
-        boxed_triplet
-        .unbox();
-
-    array![PREPROCESSED_COLUMN_LOG_SIZE.span(), trace_log_sizes, interaction_log_sizes]
-}
 
 #[derive(Drop)]
 #[cfg(not(feature: "poseidon252_verifier"))]

--- a/stwo_cairo_verifier/crates/cairo_air/src/claims.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/claims.cairo
@@ -1,12 +1,12 @@
 // This file was created by the AIR team.
 
+use stwo_cairo_air::preprocessed_columns::PREPROCESSED_COLUMN_LOG_SIZE;
 use stwo_cairo_air::{PublicData, RelationUsesDict};
 use stwo_constraint_framework::claim::ClaimTrait;
-use stwo_constraint_framework::tree_array_concat_cols;
+use stwo_constraint_framework::{override_preprocessed_trace_log_sizes, tree_array_concat_cols};
 use stwo_verifier_core::TreeArray;
 use stwo_verifier_core::channel::Channel;
 use stwo_verifier_core::utils::OptionImpl;
-use crate::cairo_air::override_preprocessed_trace_log_sizes;
 use crate::components;
 use crate::components::memory_address_to_id::MEMORY_ADDRESS_TO_ID_SPLIT;
 use crate::components::{
@@ -319,7 +319,9 @@ pub impl CairoClaimImpl of ClaimTrait<CairoClaim> {
             log_sizes_list.append(claim.log_sizes());
         }
         let aggregated_log_sizes = tree_array_concat_cols(log_sizes_list);
-        override_preprocessed_trace_log_sizes(aggregated_log_sizes)
+        override_preprocessed_trace_log_sizes(
+            aggregated_log_sizes, PREPROCESSED_COLUMN_LOG_SIZE.span(),
+        )
     }
 
     fn mix_into(self: @CairoClaim, ref channel: Channel) {

--- a/stwo_cairo_verifier/crates/circuit_air/src/circuit_air.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/circuit_air.cairo
@@ -1,0 +1,258 @@
+use core::box::BoxImpl;
+use core::num::traits::Zero;
+use stwo_constraint_framework::{
+    AirComponent, CommonLookupElements, PreprocessedMaskValuesImpl, validate_mask_usage,
+};
+use stwo_verifier_core::circle::CirclePoint;
+use stwo_verifier_core::fields::qm31::{QM31, QM31_EXTENSION_DEGREE};
+use stwo_verifier_core::verifier::Air;
+use stwo_verifier_core::{ColumnSpan, TreeSpan};
+use crate::claims::CircuitInteractionClaim;
+use crate::component_indices::*;
+use crate::components;
+
+/// Circuit components, in `crate::component_indices` order.
+#[derive(Drop)]
+pub struct CircuitAir {
+    pub eq: components::eq::Component,
+    pub qm31_ops: components::qm31_ops::Component,
+    pub triple_xor: components::triple_xor::Component,
+    pub m_31_to_u_32: components::m_31_to_u_32::Component,
+    pub blake_g_gate: components::blake_g_gate::Component,
+    pub verify_bitwise_xor_8: components::verify_bitwise_xor_8::Component,
+    pub verify_bitwise_xor_12: components::verify_bitwise_xor_12::Component,
+    pub verify_bitwise_xor_4: components::verify_bitwise_xor_4::Component,
+    pub verify_bitwise_xor_7: components::verify_bitwise_xor_7::Component,
+    pub verify_bitwise_xor_9: components::verify_bitwise_xor_9::Component,
+    pub range_check_16: components::range_check_16::Component,
+}
+
+#[generate_trait]
+pub impl CircuitAirNewImpl of CircuitAirNewTrait {
+    /// Builds the circuit components. Component log sizes are derived verifier-side (they are
+    /// not part of the claim); `component_log_sizes` is indexed by COMPONENT_IDX. The circuit
+    /// is fixed-size, so every component is present.
+    fn new(
+        component_log_sizes: [u32; N_COMPONENTS],
+        common_lookup_elements: @CommonLookupElements,
+        interaction_claim: @CircuitInteractionClaim,
+    ) -> CircuitAir {
+        let log_sizes = component_log_sizes.span();
+        // Each component's interaction claim is its single `claimed_sum`, taken from the
+        // shared array by COMPONENT_IDX.
+        let claimed_sums = interaction_claim.claimed_sum.span();
+
+        CircuitAir {
+            eq: components::eq::NewComponentImpl::new(
+                @components::eq::Claim { log_size: *log_sizes.at(EQ_COMPONENT_IDX) },
+                *claimed_sums.at(EQ_COMPONENT_IDX),
+                common_lookup_elements,
+            ),
+            qm31_ops: components::qm31_ops::NewComponentImpl::new(
+                @components::qm31_ops::Claim { log_size: *log_sizes.at(QM31_OPS_COMPONENT_IDX) },
+                *claimed_sums.at(QM31_OPS_COMPONENT_IDX),
+                common_lookup_elements,
+            ),
+            triple_xor: components::triple_xor::NewComponentImpl::new(
+                @components::triple_xor::Claim {
+                    log_size: *log_sizes.at(TRIPLE_XOR_COMPONENT_IDX),
+                },
+                *claimed_sums.at(TRIPLE_XOR_COMPONENT_IDX),
+                common_lookup_elements,
+            ),
+            m_31_to_u_32: components::m_31_to_u_32::NewComponentImpl::new(
+                @components::m_31_to_u_32::Claim {
+                    log_size: *log_sizes.at(M_31_TO_U_32_COMPONENT_IDX),
+                },
+                *claimed_sums.at(M_31_TO_U_32_COMPONENT_IDX),
+                common_lookup_elements,
+            ),
+            blake_g_gate: components::blake_g_gate::NewComponentImpl::new(
+                @components::blake_g_gate::Claim {
+                    log_size: *log_sizes.at(BLAKE_G_GATE_COMPONENT_IDX),
+                },
+                *claimed_sums.at(BLAKE_G_GATE_COMPONENT_IDX),
+                common_lookup_elements,
+            ),
+            verify_bitwise_xor_8: components::verify_bitwise_xor_8::NewComponentImpl::new(
+                @components::verify_bitwise_xor_8::Claim {},
+                *claimed_sums.at(VERIFY_BITWISE_XOR_8_COMPONENT_IDX),
+                common_lookup_elements,
+            ),
+            verify_bitwise_xor_12: components::verify_bitwise_xor_12::NewComponentImpl::new(
+                @components::verify_bitwise_xor_12::Claim {},
+                *claimed_sums.at(VERIFY_BITWISE_XOR_12_COMPONENT_IDX),
+                common_lookup_elements,
+            ),
+            verify_bitwise_xor_4: components::verify_bitwise_xor_4::NewComponentImpl::new(
+                @components::verify_bitwise_xor_4::Claim {},
+                *claimed_sums.at(VERIFY_BITWISE_XOR_4_COMPONENT_IDX),
+                common_lookup_elements,
+            ),
+            verify_bitwise_xor_7: components::verify_bitwise_xor_7::NewComponentImpl::new(
+                @components::verify_bitwise_xor_7::Claim {},
+                *claimed_sums.at(VERIFY_BITWISE_XOR_7_COMPONENT_IDX),
+                common_lookup_elements,
+            ),
+            verify_bitwise_xor_9: components::verify_bitwise_xor_9::NewComponentImpl::new(
+                @components::verify_bitwise_xor_9::Claim {},
+                *claimed_sums.at(VERIFY_BITWISE_XOR_9_COMPONENT_IDX),
+                common_lookup_elements,
+            ),
+            range_check_16: components::range_check_16::NewComponentImpl::new(
+                @components::range_check_16::Claim {},
+                *claimed_sums.at(RANGE_CHECK_16_COMPONENT_IDX),
+                common_lookup_elements,
+            ),
+        }
+    }
+}
+
+pub impl CircuitAirImpl of Air<CircuitAir> {
+    fn eval_composition_polynomial_at_point(
+        self: @CircuitAir,
+        point: CirclePoint<QM31>,
+        mask_values: TreeSpan<ColumnSpan<Span<QM31>>>,
+        random_coeff: QM31,
+    ) -> QM31 {
+        let _ = point;
+        let mut sum = Zero::zero();
+
+        let [
+            preprocessed_mask_values,
+            mut trace_mask_values,
+            mut interaction_trace_mask_values,
+            _composition_trace_mask_values,
+        ]: [ColumnSpan<Span<QM31>>; QM31_EXTENSION_DEGREE] =
+            (*mask_values
+            .try_into()
+            .unwrap())
+            .unbox();
+
+        let mut preprocessed_mask_values = PreprocessedMaskValuesImpl::new(
+            preprocessed_mask_values,
+        );
+
+        // Evaluate components in `ComponentList` order — this must match the order in which the
+        // prover commits trace/interaction columns, since each component consumes its columns
+        // from the front of the mask spans.
+        let CircuitAir {
+            eq,
+            qm31_ops,
+            triple_xor,
+            m_31_to_u_32,
+            blake_g_gate,
+            verify_bitwise_xor_8,
+            verify_bitwise_xor_12,
+            verify_bitwise_xor_4,
+            verify_bitwise_xor_7,
+            verify_bitwise_xor_9,
+            range_check_16,
+        } = self;
+
+        eq
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
+        qm31_ops
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
+        triple_xor
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
+        m_31_to_u_32
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
+        blake_g_gate
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
+        verify_bitwise_xor_8
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
+        verify_bitwise_xor_12
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
+        verify_bitwise_xor_4
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
+        verify_bitwise_xor_7
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
+        verify_bitwise_xor_9
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
+        range_check_16
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
+
+        validate_mask_usage(
+            preprocessed_mask_values, trace_mask_values, interaction_trace_mask_values,
+        );
+        sum
+    }
+}

--- a/stwo_cairo_verifier/crates/circuit_air/src/lib.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/lib.cairo
@@ -1,6 +1,7 @@
 //! `stwo_circuit_air`: AIR-specific verifier-side logic written in Cairo for the stwo-circuits
 //! circuit.
 
+pub mod circuit_air;
 pub mod claims;
 pub mod component_indices;
 pub mod components;

--- a/stwo_cairo_verifier/crates/constraint_framework/src/lib.cairo
+++ b/stwo_cairo_verifier/crates/constraint_framework/src/lib.cairo
@@ -1,13 +1,14 @@
+use core::box::BoxImpl;
 use core::dict::{Felt252Dict, Felt252DictEntryTrait, Felt252DictTrait, SquashedFelt252DictTrait};
 use core::nullable::{Nullable, NullableTrait};
 use core::num::traits::One;
-use stwo_verifier_core::ColumnSpan;
 use stwo_verifier_core::channel::{Channel, ChannelTrait};
 use stwo_verifier_core::fields::m31::M31;
 #[cfg(not(feature: "qm31_opcode"))]
 use stwo_verifier_core::fields::m31::MulByM31Trait;
 use stwo_verifier_core::fields::qm31::QM31;
 use stwo_verifier_core::utils::{ArrayImpl, pow2};
+use stwo_verifier_core::{ColumnSpan, TreeArray};
 
 pub mod claim;
 pub mod component;
@@ -168,6 +169,43 @@ pub impl PreprocessedMaskValuesImpl of PreprocessedMaskValuesTrait {
             assert!(used);
         }
     }
+}
+
+/// Validates that every `mask_value` provided in the proof (in `sampled_values`) is used by at
+/// least one component.
+///
+/// Since `eval_composition_polynomial_at_point` is responsible for validating the *structure*
+/// of `sampled_values` in the proof, it needs to ensure that all sampled preprocessed
+/// mask values are actually used. Otherwise, the prover would have the freedom to
+/// send a sample of a column even if it is unused, adding another term to the FRI quotients.
+///
+/// Additionally, there is a sanity check that the columns in the trace and interaction-trace were
+/// consumed by the components.
+/// This is not strictly necessary as the verifier generates the column indices on its own and only
+/// access samples of columns for which it knows about.
+pub fn validate_mask_usage(
+    preprocessed_mask_values: PreprocessedMaskValues,
+    trace_mask_values: ColumnSpan<Span<QM31>>,
+    interaction_trace_mask_values: ColumnSpan<Span<QM31>>,
+) {
+    preprocessed_mask_values.validate_usage();
+    assert!(trace_mask_values.is_empty());
+    assert!(interaction_trace_mask_values.is_empty());
+}
+
+/// Override the preprocessed trace log sizes, since they come from a global setting
+/// rather than computed by concatenating preprocessed log sizes of the individual
+/// components.
+/// TODO(ilya): consider removing the generation of `_invalid_preprocessed_trace_log_sizes`.
+pub fn override_preprocessed_trace_log_sizes(
+    aggregated_log_sizes: TreeArray<Span<u32>>, preprocessed_column_log_sizes: Span<u32>,
+) -> TreeArray<Span<u32>> {
+    let boxed_triplet: Box<[Span<u32>; 3]> = *aggregated_log_sizes.span().try_into().unwrap();
+    let [_invalid_preprocessed_trace_log_sizes, trace_log_sizes, interaction_log_sizes] =
+        boxed_triplet
+        .unbox();
+
+    array![preprocessed_column_log_sizes, trace_log_sizes, interaction_log_sizes]
 }
 
 #[derive(Debug, Default, Drop)]


### PR DESCRIPTION
Adds `circuit_air.cairo` with:
  - `CircuitAir` struct holding all 16 components.
  - `CircuitAirNewImpl::new` building the components from per-component
    claims, the common lookup elements, and the interaction claim.
  - `Air<CircuitAir>` impl whose
    `eval_composition_polynomial_at_point` walks the 16 components in
    order and accumulates their constraint contributions.
  - `validate_mask_usage`: asserts every preprocessed mask value supplied
    in the proof was actually consumed (matches
    `cairo_air::cairo_air::validate_mask_usage`).
  - `override_preprocessed_trace_log_sizes`: replaces the
    per-component-aggregated preprocessed log sizes with the verifier's
    flat preprocessed-trace layout (preprocessed trace is one flat trace
    for the whole circuit, not a concatenation).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1775)
<!-- Reviewable:end -->
