### PR TITLE
circuit_air: add verify_circuit entry point

### DIFF
--- a/stwo_cairo_verifier/crates/circuit_air/src/lib.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/lib.cairo
@@ -1,11 +1,219 @@
 //! `stwo_circuit_air`: AIR-specific verifier-side logic written in Cairo for the stwo-circuits
 //! circuit.
+use circuit_air::CircuitAirNewImpl;
+use core::dict::{Felt252DictTrait, SquashedFelt252DictTrait};
+use core::num::traits::Zero;
+use privacy_consts::{
+    LIFTING_LOG_SIZE, N_OUTPUTS, PREPROCESSED_COLUMN_LOG_SIZES, circuit_pcs_config,
+    preprocessed_root,
+};
+use stwo_constraint_framework::LookupElementsImpl;
+pub use stwo_constraint_framework::{RelationUse, RelationUsesDict, accumulate_relation_uses};
+use stwo_verifier_core::Hash;
+use stwo_verifier_core::channel::{Channel, ChannelTrait};
+use stwo_verifier_core::fields::m31::{M31Trait, P_U32};
+#[cfg(not(feature: "poseidon252_verifier"))]
+use stwo_verifier_core::fields::qm31::QM31Trait;
+use stwo_verifier_core::fields::qm31::{QM31, QM31Serde};
+use stwo_verifier_core::pcs::PcsConfigTrait;
+use stwo_verifier_core::pcs::verifier::CommitmentSchemeVerifierImpl;
+#[cfg(not(feature: "poseidon252_verifier"))]
+use stwo_verifier_core::vcs::blake2s_hasher::Blake2sHash;
+use stwo_verifier_core::verifier::{StarkProof, VerificationError, verify};
+#[cfg(not(feature: "poseidon252_verifier"))]
+use stwo_verifier_utils::blake2s::hash_u32s;
 
 pub mod circuit_air;
+
 pub mod claims;
 pub mod component_indices;
+use claims::{
+    CircuitClaim, CircuitClaimImpl, CircuitInteractionClaim, CircuitInteractionClaimImpl,
+    accumulate_circuit_relation_uses, column_log_sizes_per_tree, derive_component_log_sizes,
+    lookup_sum,
+};
+use component_indices::N_COMPONENTS;
 pub mod components;
 pub mod prelude;
 pub mod preprocessed_columns;
 pub mod privacy_consts;
 pub mod relations;
+
+// Security constants.
+pub const INTERACTION_POW_BITS: u32 = 20;
+const SECURITY_BITS: u32 = 96;
+
+pub const P_U32_CONST: u32 = P_U32;
+
+#[derive(Drop, Serde)]
+pub struct CircuitProof {
+    pub claim: CircuitClaim,
+    pub interaction_pow: u64,
+    pub interaction_claim: CircuitInteractionClaim,
+    pub stark_proof: StarkProof,
+    /// Salt used in the channel initialization.
+    pub channel_salt: u32,
+}
+
+/// The output of a circuit verification: `blake2s(preprocessed_root || output_values)`
+#[derive(Drop, Serde)]
+pub struct VerificationOutput {
+    pub output_hash: Hash,
+}
+
+/// Returns the output of the verifier: `blake2s(preprocessed_root || output_values)`.
+#[cfg(not(feature: "poseidon252_verifier"))]
+pub fn get_verification_output(proof: @CircuitProof) -> VerificationOutput {
+    let [r0, r1, r2, r3, r4, r5, r6, r7] = preprocessed_root().hash.unbox();
+    let mut words = array![r0, r1, r2, r3, r4, r5, r6, r7];
+    for value in proof.claim.public_data.output_values.span() {
+        let [c0, c1, c2, c3] = (*value).to_fixed_array();
+        words.append(c0.into());
+        words.append(c1.into());
+        words.append(c2.into());
+        words.append(c3.into());
+    }
+    VerificationOutput { output_hash: Blake2sHash { hash: hash_u32s(words.span()) } }
+}
+
+#[cfg(feature: "poseidon252_verifier")]
+pub fn get_verification_output(_proof: @CircuitProof) -> VerificationOutput {
+    panic!("the privacy recursive circuit verifier only supports the blake2s hasher")
+}
+
+pub fn verify_circuit(proof: CircuitProof) {
+    let CircuitProof {
+        claim, interaction_pow, interaction_claim, stark_proof, channel_salt,
+    } = proof;
+
+    let preprocessed_column_log_sizes = PREPROCESSED_COLUMN_LOG_SIZES;
+
+    // The circuit produces a fixed number of public outputs (its topology); the claim must
+    // provide exactly that many.
+    assert!(claim.public_data.output_values.len() == N_OUTPUTS);
+
+    // Pin the proof's PCS config to the circuit's hardcoded canonical config. This rejects any
+    // proof produced with weaker/mismatched FRI parameters, and guarantees
+    // `lifting_log_size == LIFTING_LOG_SIZE` and that `log_blowup_factor` matches the blowup the
+    // hardcoded `preprocessed_root()` was committed at.
+    let pcs_config = stark_proof.commitment_scheme_proof.config;
+    assert!(pcs_config == circuit_pcs_config(), "unexpected proof pcs config");
+    let lifting_log_size = LIFTING_LOG_SIZE;
+
+    // Component log sizes are derived verifier-side from the hardcoded preprocessed column log
+    // sizes; they are not carried in the claim.
+    let component_log_sizes = derive_component_log_sizes(preprocessed_column_log_sizes.span());
+
+    verify_claim(component_log_sizes);
+
+    let mut channel: Channel = Default::default();
+    // Mix channel salt. Note that we first reduce it modulo `M31::P`, then cast it as QM31.
+    let channel_salt_as_felt: QM31 = M31Trait::reduce_u32(channel_salt).into();
+    channel.mix_felts([channel_salt_as_felt].span());
+
+    pcs_config.mix_into(ref channel);
+    let mut commitment_scheme = CommitmentSchemeVerifierImpl::new();
+
+    // Unpack commitments.
+    let commitments: @Box<[Hash; 4]> = stark_proof
+        .commitment_scheme_proof
+        .commitments
+        .try_into()
+        .unwrap();
+    let [
+        preprocessed_commitment,
+        trace_commitment,
+        interaction_trace_commitment,
+        composition_commitment,
+    ] =
+        commitments
+        .unbox();
+
+    let log_sizes = column_log_sizes_per_tree(component_log_sizes);
+    let log_sizes_box: @Box<[Span<u32>; 3]> = log_sizes.span().try_into().unwrap();
+    let [_, trace_log_sizes, interaction_trace_log_sizes] = log_sizes_box.unbox();
+
+    let log_blowup_factor = pcs_config.fri_config.log_blowup_factor;
+
+    // Preprocessed trace. The preprocessed column log sizes are the hardcoded ones rather than
+    // the values derived from `component_log_sizes`.
+    assert!(preprocessed_commitment == preprocessed_root());
+    commitment_scheme
+        .commit(
+            preprocessed_commitment,
+            preprocessed_column_log_sizes.span(),
+            ref channel,
+            log_blowup_factor,
+        );
+
+    // Claim and base trace.
+    claim.mix_into(ref channel);
+    commitment_scheme.commit(trace_commitment, trace_log_sizes, ref channel, log_blowup_factor);
+
+    // Interaction proof of work.
+    assert!(
+        channel.verify_pow_nonce(INTERACTION_POW_BITS, interaction_pow),
+        "{}",
+        VerificationError::InteractionProofOfWork,
+    );
+    channel.mix_u64(interaction_pow);
+
+    // Pick the interaction elements.
+    let common_lookup_elements = LookupElementsImpl::draw(ref channel);
+    assert!(
+        lookup_sum(@claim, @common_lookup_elements, @interaction_claim).is_zero(),
+        "{}",
+        VerificationError::InvalidLogupSum,
+    );
+
+    // Interaction trace.
+    interaction_claim.mix_into(ref channel);
+    commitment_scheme
+        .commit(
+            interaction_trace_commitment,
+            interaction_trace_log_sizes,
+            ref channel,
+            log_blowup_factor,
+        );
+
+    // The circuit commits all trees at the lifted height. `verify` expects the trace's log
+    // degree bound (`trace_log_size = lifting - blowup`); the composition polynomial's raw
+    // degree bound is one higher (degree-2 constraints) but it is split into 2 polynomials
+    // before LDE, bringing its per-column degree bound back down to the trace's.
+    let trace_log_degree_bound = lifting_log_size - log_blowup_factor;
+    let circuit_air = CircuitAirNewImpl::new(
+        component_log_sizes, @common_lookup_elements, @interaction_claim,
+    );
+
+    verify(
+        stark_proof,
+        circuit_air,
+        trace_log_degree_bound,
+        composition_commitment,
+        commitment_scheme,
+        ref channel,
+        SECURITY_BITS,
+    );
+}
+
+/// Verifies the claim of the circuit proof.
+///
+/// Checks that, for every lookup relation, the total number of uses across all components is
+/// less than `P`. This mirrors the soundness requirement enforced by
+/// `stwo-circuits/crates/stark_verifier/src/verify.rs::check_relation_uses`; the Rust version
+/// has to work in the QM31 circuit domain and therefore uses a shifted sum
+/// (`sum(uses_per_row * (floor(num_rows/DIV) + 1)) < floor(P/DIV)`) to avoid overflow.
+/// In Cairo we have native `u64` arithmetic, so the accumulator in
+/// `stwo_constraint_framework::accumulate_relation_uses` already sums directly — the check
+/// here is the plain `< P` bound on that accumulated `u64`.
+fn verify_claim(component_log_sizes: [u32; N_COMPONENTS]) {
+    let mut relation_uses: RelationUsesDict = Default::default();
+    accumulate_circuit_relation_uses(component_log_sizes, ref relation_uses);
+
+    let squashed = relation_uses.squash();
+    let entries = squashed.into_entries();
+    for entry in entries {
+        let (_relation_id, _first_uses, last_uses) = entry;
+        assert!(last_uses < P_U32.into(), "A relation has more than P-1 uses");
+    }
+}

--- a/stwo_cairo_verifier/crates/circuit_air/src/privacy_consts.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/privacy_consts.cairo
@@ -10,12 +10,33 @@
 
 use core::box::BoxImpl;
 use stwo_verifier_core::Hash;
+use stwo_verifier_core::fri::FriConfig;
+use stwo_verifier_core::pcs::PcsConfig;
 #[cfg(not(feature: "poseidon252_verifier"))]
 use stwo_verifier_core::vcs::blake2s_hasher::Blake2sHash;
 
 /// Lifting log size of the recursive verification circuit's proof: the value carried in
 /// the proof's `pcs_config.lifting_log_size` (trace_log_size 20 + log_blowup_factor 2).
 pub const LIFTING_LOG_SIZE: u32 = 22;
+
+/// Expected PCS config of the recursive verification circuit's proof.
+///
+/// Hardcoded so the verifier accepts only proofs produced with the circuit's canonical
+/// configuration. This pins every FRI security parameter (a weaker config — fewer queries,
+/// smaller blowup, or less proof-of-work — is rejected, independently of stwo's
+/// `security_bits >= SECURITY_BITS` floor) and ties `log_blowup_factor` to the blowup the
+/// hardcoded `preprocessed_root()` was committed at. Must match the rust prover's
+/// `CIRCUIT_PCS_CONFIG` (proving-utils), with the prover-clamped `lifting_log_size`.
+/// Note `pow_bits + log_blowup_factor * n_queries = 26 + 2 * 35 = 96 = SECURITY_BITS`.
+pub fn circuit_pcs_config() -> PcsConfig {
+    PcsConfig {
+        pow_bits: 26,
+        fri_config: FriConfig {
+            log_blowup_factor: 2, log_last_layer_degree_bound: 0, n_queries: 35, fold_step: 4,
+        },
+        lifting_log_size: Option::Some(LIFTING_LOG_SIZE),
+    }
+}
 
 /// Number of public output values of the recursive verification circuit.
 ///

--- a/stwo_cairo_verifier/crates/verifier_core/src/fri.cairo
+++ b/stwo_cairo_verifier/crates/verifier_core/src/fri.cairo
@@ -19,7 +19,7 @@ use crate::vcs::verifier::{MerkleDecommitment, MerkleVerifier, MerkleVerifierTra
 /// Number of QM31 evaluations packed into a single Merkle leaf when `fold_step > 1`.
 pub const LOG_PACKED_LEAF_SIZE: u32 = 2;
 
-#[derive(Drop, Serde, Copy)]
+#[derive(Drop, Serde, Copy, PartialEq)]
 pub struct FriConfig {
     pub log_blowup_factor: u32,
     pub log_last_layer_degree_bound: u32,

--- a/stwo_cairo_verifier/crates/verifier_core/src/pcs.cairo
+++ b/stwo_cairo_verifier/crates/verifier_core/src/pcs.cairo
@@ -17,7 +17,7 @@ pub mod verifier;
 #[cfg(test)]
 mod verifier_test;
 
-#[derive(Drop, Serde, Copy)]
+#[derive(Drop, Serde, Copy, PartialEq)]
 pub struct PcsConfig {
     pub pow_bits: u32,
     pub fri_config: FriConfig,


### PR DESCRIPTION
Final body of `circuit_air/src/lib.cairo`:

  - `CircuitProof`: top-level proof struct (claim, interaction PoW,
    interaction claim, stark proof, channel salt).
  - `VerificationOutput` + `get_verification_output`: extracts the
    circuit's public output values from the proof.
  - `verify_circuit`: end-to-end verifier matching the structure of
    `cairo_air::verify_cairo`. Uses the standard
    `pcs_config.mix_into(ref channel, Option::Some(*config.lifting_log_size))`
    to thread the prover's `lifting_log_size` into the Fiat-Shamir
    channel. Threads the same `lifting_log_size_opt` into every
    `commit` call and into `verify` (matching stwo's
    `MerkleVerifierLifted::new(.., Some(h))`).
  - `verify_claim`: per-relation `< P` bound check, mirroring stwo-circuits'
    `check_relation_uses`.
  - `CircuitVerificationError`: error enum.

Security constants `INTERACTION_POW_BITS = 20` and `SECURITY_BITS = 96`
must match `stwo-circuits/crates/cairo_air/src/verify.rs`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1783)
<!-- Reviewable:end -->
