### PR TITLE
Build stwo-cairo-prover on Rust 1.94 nightly

### DIFF
--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -1849,6 +1849,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
+ "serde",
 ]
 
 [[package]]
@@ -3371,8 +3372,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "stwo"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d400ae91acbeafa6f80070a03e1117a794a95f295050f44538a4c7dd55abd491"
+source = "git+https://github.com/starkware-libs/stwo?rev=489a0f3e#489a0f3ee44a59e03944ad9aa4f3e5a91a3d3f08"
 dependencies = [
  "blake2",
  "blake3",
@@ -3381,7 +3381,7 @@ dependencies = [
  "dashmap",
  "educe 0.5.11",
  "fnv",
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
  "hex",
  "indexmap",
  "itertools 0.12.1",
@@ -3400,8 +3400,7 @@ dependencies = [
 [[package]]
 name = "stwo-air-utils"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5024a5129f74a675865e6b8d72ebddfc63cb384f9f69405440b66cad5f99b2"
+source = "git+https://github.com/starkware-libs/stwo?rev=489a0f3e#489a0f3ee44a59e03944ad9aa4f3e5a91a3d3f08"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -3413,8 +3412,7 @@ dependencies = [
 [[package]]
 name = "stwo-air-utils-derive"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39432b7b0d1b9e5ed34ca174164dd2d640ec32c475b263da0b9630ba746f8753"
+source = "git+https://github.com/starkware-libs/stwo?rev=489a0f3e#489a0f3ee44a59e03944ad9aa4f3e5a91a3d3f08"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -3567,10 +3565,9 @@ dependencies = [
 [[package]]
 name = "stwo-constraint-framework"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aca0d5d36d4b015703fb14f162a23cb685e67f8aa08dbe7faf39bd66fe93f1"
+source = "git+https://github.com/starkware-libs/stwo?rev=489a0f3e#489a0f3ee44a59e03944ad9aa4f3e5a91a3d3f08"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
  "itertools 0.12.1",
  "num-traits",
  "rand 0.8.5",

--- a/stwo_cairo_prover/Cargo.toml
+++ b/stwo_cairo_prover/Cargo.toml
@@ -55,10 +55,10 @@ stwo-cairo-common = { path = "crates/common", version = "~1.2.2" }
 cairo-air = { path = "crates/cairo-air", version = "~1.2.2" }
 stwo-cairo-serialize = { path = "crates/cairo-serialize", version = "~1.2.2" }
 stwo-cairo-serialize-derive = { path = "crates/cairo-serialize-derive", version = "~1.2.2" }
-stwo = "2.2.0"
-stwo-constraint-framework = "2.2.0"
-stwo-air-utils-derive = "2.2.0"
-stwo-air-utils = "2.2.0"
+stwo = { git = "https://github.com/starkware-libs/stwo", rev = "489a0f3e" }
+stwo-constraint-framework = { git = "https://github.com/starkware-libs/stwo", rev = "489a0f3e" }
+stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "489a0f3e" }
+stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "489a0f3e" }
 test-case = "3.3.1"
 thiserror = { version = "2.0.12", default-features = false }
 tracing = "0.1.40"

--- a/stwo_cairo_prover/crates/prover/src/lib.rs
+++ b/stwo_cairo_prover/crates/prover/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(portable_simd, iter_array_chunks, array_chunks, raw_slice_split)]
+#![feature(portable_simd, iter_array_chunks, raw_slice_split)]
 #![allow(clippy::too_many_arguments)]
 
 pub use stwo;

--- a/stwo_cairo_prover/crates/prover/src/witness/components/memory_address_to_id.rs
+++ b/stwo_cairo_prover/crates/prover/src/witness/components/memory_address_to_id.rs
@@ -51,7 +51,7 @@ impl AddressToId {
     }
 
     pub fn array_chunks<const N: usize>(&self) -> impl Iterator<Item = &[u32; N]> {
-        self.data.array_chunks::<N>()
+        self.data.as_chunks::<N>().0.iter()
     }
 }
 

--- a/stwo_cairo_prover/crates/prover/src/witness/utils.rs
+++ b/stwo_cairo_prover/crates/prover/src/witness/utils.rs
@@ -24,7 +24,9 @@ use crate::witness::preprocessed_trace::generate_preprocessed_commitment_root;
 
 pub fn pack_values<T: Pack>(values: &[T]) -> Vec<T::SimdType> {
     values
-        .array_chunks::<N_LANES>()
+        .as_chunks::<N_LANES>()
+        .0
+        .iter()
         .map(|c| T::pack(*c))
         .collect()
 }
@@ -144,7 +146,9 @@ pub fn export_preprocessed_roots() {
         );
         let root_bytes = root.0;
         let u32s_hex = root_bytes
-            .array_chunks::<4>()
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|&bytes| format!("{:#010x}", u32::from_le_bytes(bytes)))
             .collect_vec()
             .join(", ");
@@ -183,7 +187,9 @@ pub fn export_circuit_cairo_verifier_preprocessed_roots() {
 
         let root_bytes = root.0;
         let u32s = root_bytes
-            .array_chunks::<4>()
+            .as_chunks::<4>()
+            .0
+            .iter()
             .map(|&bytes| format!("{:}", u32::from_le_bytes(bytes)))
             .collect_vec()
             .join(", ");

--- a/stwo_cairo_prover/rust-toolchain.toml
+++ b/stwo_cairo_prover/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-06-23"
+channel = "nightly-2026-01-15"


### PR DESCRIPTION
## What
Makes `stwo-cairo-prover` compile on the Rust **1.94** nightly toolchain.

## Why
Rust 1.94 removed the unstable slice `array_chunks` method (the `array_chunks` library feature is gone — `error[E0635]: unknown feature`). The upstream `stwo` 2.2.0 prover and our own witness-generation code both relied on it.

## Changes
- Point the `stwo` deps (`stwo`, `stwo-constraint-framework`, `stwo-air-utils`, `stwo-air-utils-derive`) at the 1.94-compatible stwo branch, pinned to `rev = 489a0f3e` (`gil/rust-1.94-nightly`). This is `stwo` v2.2.0 + the 1.94 compile fixes — API-identical to the published 2.2.0.
- Replace the removed slice `array_chunks::<N>()` with `as_chunks::<N>().0.iter()` in `witness/utils.rs` and the `AddressToId::array_chunks` wrapper. The `Iterator::array_chunks` adaptor uses (`memory_id_to_big.rs`) are unchanged — that's the separate `iter_array_chunks` feature, which still exists.
- Drop `array_chunks` from `prover/src/lib.rs`'s `#![feature(...)]` list (keeping `iter_array_chunks`).
- Bump `rust-toolchain.toml` to `nightly-2026-01-15`.

Branched off `0a5e70b7` (the commit currently pinned downstream by proving-utils / stwo-circuits).

## Verification
`cargo +nightly-2026-01-15 check -p stwo-cairo-prover` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1787)
<!-- Reviewable:end -->
