### PR TITLE
fix(verifier): bind expected preprocessed roots

### DIFF
--- a/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
@@ -301,6 +301,8 @@ where
 }
 
 pub enum ExpectedPreprocessedRootPolicy<Hash> {
+    /// This verifier configuration intentionally has no built-in static preprocessed root.
+    /// Callers must not infer root binding for modes that return this policy.
     NoStaticRoot,
     Exact(Hash),
 }

--- a/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
@@ -8,10 +8,16 @@ use stwo::core::fields::m31::BaseField;
 use stwo::core::fields::qm31::SecureField;
 use stwo::core::pcs::CommitmentSchemeVerifier;
 use stwo::core::verifier::{verify_ex, VerificationError};
+use stwo::core::vcs_lifted::blake2_hash::Blake2sHash;
+use stwo::core::vcs_lifted::blake2_merkle::{Blake2sM31MerkleChannel, Blake2sMerkleChannel};
+use stwo::core::vcs_lifted::merkle_hasher::MerkleHasherLifted;
+use stwo::core::vcs_lifted::poseidon252_merkle::Poseidon252MerkleChannel;
 use stwo_cairo_common::builtins::*;
 use stwo_cairo_common::memory::{LARGE_MEMORY_VALUE_ID_BASE, LOG_MEMORY_ADDRESS_BOUND};
+use stwo_cairo_common::preprocessed_columns::preprocessed_trace::PreProcessedTraceVariant;
 use stwo_cairo_common::prover_types::cpu::{CasmState, PRIME};
 use stwo_constraint_framework::PREPROCESSED_TRACE_IDX;
+use starknet_ff::FieldElement as FieldElement252;
 use thiserror::Error;
 use tracing::{span, Level};
 
@@ -280,13 +286,93 @@ fn check_builtin(
 /// 1 << (24 + INTERACTION_POW_BITS) relation terms.
 pub const INTERACTION_POW_BITS: u32 = 24;
 
-pub fn verify_cairo<MC: MerkleChannel>(
+pub trait ExpectedPreprocessedRoot: MerkleChannel
+where
+    Self::H: MerkleHasherLifted,
+{
+    fn expected_preprocessed_root(
+        variant: PreProcessedTraceVariant,
+        log_blowup_factor: u32,
+        lifting_log_size: Option<u32>,
+    ) -> Option<<Self::H as MerkleHasherLifted>::Hash>;
+}
+
+impl ExpectedPreprocessedRoot for Blake2sMerkleChannel {
+    fn expected_preprocessed_root(
+        variant: PreProcessedTraceVariant,
+        log_blowup_factor: u32,
+        lifting_log_size: Option<u32>,
+    ) -> Option<<Self::H as MerkleHasherLifted>::Hash> {
+        if variant != PreProcessedTraceVariant::Canonical || lifting_log_size.is_some() {
+            return None;
+        }
+        let root = match log_blowup_factor {
+            1 => [
+                0x42228ea9, 0x35d2f53b, 0x360b1f98, 0x56ae39d9, 0x75e23bef, 0x32b0581c,
+                0x6e1e83b2, 0x6403ba24,
+            ],
+            2 => [
+                0x7094e904, 0x210a38ad, 0x126b6cee, 0x57097de8, 0x1c860da1, 0x91b704b1,
+                0xc6cf280a, 0x8a211523,
+            ],
+            3 => [
+                0x84cb79b9, 0xb050ad16, 0x69787584, 0xcf7f274f, 0x399792c8, 0xecf77fed,
+                0x458488fe, 0xe27bbcac,
+            ],
+            4 => [
+                0x803fe777, 0x1d9267a0, 0xe383c36d, 0x2b1b4bf0, 0x9a47969f, 0xcb683ef4,
+                0x598eca47, 0x09db42f9,
+            ],
+            5 => [
+                0xbfee7cd5, 0x429ca185, 0xa8d60ba7, 0x3856e072, 0xb88de2aa, 0x12ab5bc3,
+                0xde44271d, 0x2500318a,
+            ],
+            _ => return None,
+        };
+        Some(Blake2sHash(root.map(u32::to_le_bytes).concat().try_into().unwrap()))
+    }
+}
+
+impl ExpectedPreprocessedRoot for Blake2sM31MerkleChannel {
+    fn expected_preprocessed_root(
+        _variant: PreProcessedTraceVariant,
+        _log_blowup_factor: u32,
+        _lifting_log_size: Option<u32>,
+    ) -> Option<<Self::H as MerkleHasherLifted>::Hash> {
+        None
+    }
+}
+
+impl ExpectedPreprocessedRoot for Poseidon252MerkleChannel {
+    fn expected_preprocessed_root(
+        variant: PreProcessedTraceVariant,
+        log_blowup_factor: u32,
+        lifting_log_size: Option<u32>,
+    ) -> Option<<Self::H as MerkleHasherLifted>::Hash> {
+        if variant != PreProcessedTraceVariant::CanonicalWithoutPedersen
+            || lifting_log_size.is_some()
+        {
+            return None;
+        }
+        let root = match log_blowup_factor {
+            1 => "0x1fdacd6e29834987926672fcac7fda0577adce49999ad96fb0195e745e9ce0",
+            2 => "0x14103a81a8417d83c41bc877194607103f9e1cb4cb188e5f21b75499709bbb6",
+            3 => "0x20861f94b3cf37baf1939d20691d38630596bce389dcee5f224ef1f5682e70f",
+            4 => "0x26f3a39ddf7042fefdd2595bf4739063e044845418839b2b1ec556fdc1aecf",
+            5 => "0x2111b7db0f7fb2f629d493661207663b88609e5abebbe7e59c4f116dc3dac0",
+            _ => return None,
+        };
+        FieldElement252::from_hex_be(root).ok()
+    }
+}
+
+pub fn verify_cairo<MC: ExpectedPreprocessedRoot>(
     proof: CairoProofForRustVerifier<MC::H>,
 ) -> Result<(), CairoVerificationError> {
     verify_cairo_ex::<MC>(proof, false)
 }
 
-pub fn verify_cairo_ex<MC: MerkleChannel>(
+pub fn verify_cairo_ex<MC: ExpectedPreprocessedRoot>(
     CairoProofForRustVerifier {
         claim,
         interaction_pow,
@@ -322,6 +408,16 @@ pub fn verify_cairo_ex<MC: MerkleChannel>(
             .to_preprocessed_trace()
             .log_sizes(),
     );
+
+    if let Some(expected_preprocessed_root) = MC::expected_preprocessed_root(
+        preprocessed_trace_variant,
+        pcs_config.fri_config.log_blowup_factor,
+        pcs_config.lifting_log_size,
+    ) {
+        if stark_proof.commitments[0] != expected_preprocessed_root {
+            return Err(CairoVerificationError::InvalidPreprocessedRoot);
+        }
+    }
 
     // Preproccessed trace.
     commitment_scheme_verifier.commit(stark_proof.commitments[0], &log_sizes[0], channel);
@@ -366,6 +462,8 @@ pub fn verify_cairo_ex<MC: MerkleChannel>(
 pub enum CairoVerificationError {
     #[error("Invalid logup sum")]
     InvalidLogupSum,
+    #[error("Invalid preprocessed commitment root")]
+    InvalidPreprocessedRoot,
     #[error("Stark verification error: {0}")]
     Stark(#[from] VerificationError),
     #[error("Proof of work verification failed.")]

--- a/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
@@ -8,7 +8,7 @@ use stwo::core::channel::{Channel, MerkleChannel};
 use stwo::core::fields::m31::BaseField;
 use stwo::core::fields::qm31::SecureField;
 use stwo::core::pcs::CommitmentSchemeVerifier;
-use stwo::core::vcs_lifted::blake2_hash::Blake2sHash;
+use stwo::core::vcs::blake2_hash::Blake2sHash;
 use stwo::core::vcs_lifted::blake2_merkle::{Blake2sM31MerkleChannel, Blake2sMerkleChannel};
 use stwo::core::vcs_lifted::merkle_hasher::MerkleHasherLifted;
 use stwo::core::vcs_lifted::poseidon252_merkle::Poseidon252MerkleChannel;

--- a/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
@@ -286,6 +286,12 @@ fn check_builtin(
 /// 1 << (24 + INTERACTION_POW_BITS) relation terms.
 pub const INTERACTION_POW_BITS: u32 = 24;
 
+/// Static preprocessed-root policy for Rust verifier configurations.
+///
+/// `Exact` enforces Cairo-verifier-style binding by comparing the proof's preprocessed
+/// commitment root against a verifier-known root before the root is committed to the channel.
+/// `NoStaticRoot` is an explicit opt-out: the Rust verifier commits the proof-supplied
+/// preprocessed root without this static equality check.
 pub trait ExpectedPreprocessedRoot: MerkleChannel
 where
     Self::H: MerkleHasherLifted,
@@ -302,7 +308,7 @@ where
 
 pub enum ExpectedPreprocessedRootPolicy<Hash> {
     /// This verifier configuration intentionally has no built-in static preprocessed root.
-    /// Callers must not infer root binding for modes that return this policy.
+    /// Callers must not infer Cairo-style static root binding for modes that return this policy.
     NoStaticRoot,
     Exact(Hash),
 }
@@ -393,6 +399,14 @@ impl ExpectedPreprocessedRoot for Poseidon252MerkleChannel {
     }
 }
 
+/// Verifies a Cairo proof with the Rust verifier.
+///
+/// Static preprocessed-root binding is enforced only for configurations whose
+/// [`ExpectedPreprocessedRoot`] implementation returns [`ExpectedPreprocessedRootPolicy::Exact`].
+/// The built-in exact policies are Blake2s + `Canonical` and Poseidon252 +
+/// `CanonicalWithoutPedersen`, for supported log blowup factors without lifting.
+/// Configurations that return [`ExpectedPreprocessedRootPolicy::NoStaticRoot`] remain valid
+/// verifier modes, but they do not enforce Cairo-style static preprocessed-root equality.
 pub fn verify_cairo<MC: ExpectedPreprocessedRoot>(
     proof: CairoProofForRustVerifier<MC::H>,
 ) -> Result<(), CairoVerificationError> {

--- a/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
@@ -3,21 +3,21 @@ use std::collections::HashMap;
 use num_traits::{One, Zero};
 use paste::paste;
 use serde_json::to_string_pretty;
+use starknet_ff::FieldElement as FieldElement252;
 use stwo::core::channel::{Channel, MerkleChannel};
 use stwo::core::fields::m31::BaseField;
 use stwo::core::fields::qm31::SecureField;
 use stwo::core::pcs::CommitmentSchemeVerifier;
-use stwo::core::verifier::{verify_ex, VerificationError};
 use stwo::core::vcs_lifted::blake2_hash::Blake2sHash;
 use stwo::core::vcs_lifted::blake2_merkle::{Blake2sM31MerkleChannel, Blake2sMerkleChannel};
 use stwo::core::vcs_lifted::merkle_hasher::MerkleHasherLifted;
 use stwo::core::vcs_lifted::poseidon252_merkle::Poseidon252MerkleChannel;
+use stwo::core::verifier::{verify_ex, VerificationError};
 use stwo_cairo_common::builtins::*;
 use stwo_cairo_common::memory::{LARGE_MEMORY_VALUE_ID_BASE, LOG_MEMORY_ADDRESS_BOUND};
 use stwo_cairo_common::preprocessed_columns::preprocessed_trace::PreProcessedTraceVariant;
 use stwo_cairo_common::prover_types::cpu::{CasmState, PRIME};
 use stwo_constraint_framework::PREPROCESSED_TRACE_IDX;
-use starknet_ff::FieldElement as FieldElement252;
 use thiserror::Error;
 use tracing::{span, Level};
 
@@ -294,7 +294,15 @@ where
         variant: PreProcessedTraceVariant,
         log_blowup_factor: u32,
         lifting_log_size: Option<u32>,
-    ) -> Option<<Self::H as MerkleHasherLifted>::Hash>;
+    ) -> Result<
+        ExpectedPreprocessedRootPolicy<<Self::H as MerkleHasherLifted>::Hash>,
+        CairoVerificationError,
+    >;
+}
+
+pub enum ExpectedPreprocessedRootPolicy<Hash> {
+    NoStaticRoot,
+    Exact(Hash),
 }
 
 impl ExpectedPreprocessedRoot for Blake2sMerkleChannel {
@@ -302,34 +310,42 @@ impl ExpectedPreprocessedRoot for Blake2sMerkleChannel {
         variant: PreProcessedTraceVariant,
         log_blowup_factor: u32,
         lifting_log_size: Option<u32>,
-    ) -> Option<<Self::H as MerkleHasherLifted>::Hash> {
-        if variant != PreProcessedTraceVariant::Canonical || lifting_log_size.is_some() {
-            return None;
+    ) -> Result<
+        ExpectedPreprocessedRootPolicy<<Self::H as MerkleHasherLifted>::Hash>,
+        CairoVerificationError,
+    > {
+        if variant != PreProcessedTraceVariant::Canonical {
+            return Ok(ExpectedPreprocessedRootPolicy::NoStaticRoot);
+        }
+        if lifting_log_size.is_some() {
+            return Err(CairoVerificationError::UnsupportedPreprocessedRootConfig);
         }
         let root = match log_blowup_factor {
             1 => [
-                0x42228ea9, 0x35d2f53b, 0x360b1f98, 0x56ae39d9, 0x75e23bef, 0x32b0581c,
-                0x6e1e83b2, 0x6403ba24,
+                0x42228ea9, 0x35d2f53b, 0x360b1f98, 0x56ae39d9, 0x75e23bef, 0x32b0581c, 0x6e1e83b2,
+                0x6403ba24,
             ],
             2 => [
-                0x7094e904, 0x210a38ad, 0x126b6cee, 0x57097de8, 0x1c860da1, 0x91b704b1,
-                0xc6cf280a, 0x8a211523,
+                0x7094e904, 0x210a38ad, 0x126b6cee, 0x57097de8, 0x1c860da1, 0x91b704b1, 0xc6cf280a,
+                0x8a211523,
             ],
             3 => [
-                0x84cb79b9, 0xb050ad16, 0x69787584, 0xcf7f274f, 0x399792c8, 0xecf77fed,
-                0x458488fe, 0xe27bbcac,
+                0x84cb79b9, 0xb050ad16, 0x69787584, 0xcf7f274f, 0x399792c8, 0xecf77fed, 0x458488fe,
+                0xe27bbcac,
             ],
             4 => [
-                0x803fe777, 0x1d9267a0, 0xe383c36d, 0x2b1b4bf0, 0x9a47969f, 0xcb683ef4,
-                0x598eca47, 0x09db42f9,
+                0x803fe777, 0x1d9267a0, 0xe383c36d, 0x2b1b4bf0, 0x9a47969f, 0xcb683ef4, 0x598eca47,
+                0x09db42f9,
             ],
             5 => [
-                0xbfee7cd5, 0x429ca185, 0xa8d60ba7, 0x3856e072, 0xb88de2aa, 0x12ab5bc3,
-                0xde44271d, 0x2500318a,
+                0xbfee7cd5, 0x429ca185, 0xa8d60ba7, 0x3856e072, 0xb88de2aa, 0x12ab5bc3, 0xde44271d,
+                0x2500318a,
             ],
-            _ => return None,
+            _ => return Err(CairoVerificationError::UnsupportedPreprocessedRootConfig),
         };
-        Some(Blake2sHash(root.map(u32::to_le_bytes).concat().try_into().unwrap()))
+        Ok(ExpectedPreprocessedRootPolicy::Exact(Blake2sHash(
+            root.map(u32::to_le_bytes).concat().try_into().unwrap(),
+        )))
     }
 }
 
@@ -338,8 +354,11 @@ impl ExpectedPreprocessedRoot for Blake2sM31MerkleChannel {
         _variant: PreProcessedTraceVariant,
         _log_blowup_factor: u32,
         _lifting_log_size: Option<u32>,
-    ) -> Option<<Self::H as MerkleHasherLifted>::Hash> {
-        None
+    ) -> Result<
+        ExpectedPreprocessedRootPolicy<<Self::H as MerkleHasherLifted>::Hash>,
+        CairoVerificationError,
+    > {
+        Ok(ExpectedPreprocessedRootPolicy::NoStaticRoot)
     }
 }
 
@@ -348,11 +367,15 @@ impl ExpectedPreprocessedRoot for Poseidon252MerkleChannel {
         variant: PreProcessedTraceVariant,
         log_blowup_factor: u32,
         lifting_log_size: Option<u32>,
-    ) -> Option<<Self::H as MerkleHasherLifted>::Hash> {
-        if variant != PreProcessedTraceVariant::CanonicalWithoutPedersen
-            || lifting_log_size.is_some()
-        {
-            return None;
+    ) -> Result<
+        ExpectedPreprocessedRootPolicy<<Self::H as MerkleHasherLifted>::Hash>,
+        CairoVerificationError,
+    > {
+        if variant != PreProcessedTraceVariant::CanonicalWithoutPedersen {
+            return Ok(ExpectedPreprocessedRootPolicy::NoStaticRoot);
+        }
+        if lifting_log_size.is_some() {
+            return Err(CairoVerificationError::UnsupportedPreprocessedRootConfig);
         }
         let root = match log_blowup_factor {
             1 => "0x1fdacd6e29834987926672fcac7fda0577adce49999ad96fb0195e745e9ce0",
@@ -360,9 +383,11 @@ impl ExpectedPreprocessedRoot for Poseidon252MerkleChannel {
             3 => "0x20861f94b3cf37baf1939d20691d38630596bce389dcee5f224ef1f5682e70f",
             4 => "0x26f3a39ddf7042fefdd2595bf4739063e044845418839b2b1ec556fdc1aecf",
             5 => "0x2111b7db0f7fb2f629d493661207663b88609e5abebbe7e59c4f116dc3dac0",
-            _ => return None,
+            _ => return Err(CairoVerificationError::UnsupportedPreprocessedRootConfig),
         };
-        FieldElement252::from_hex_be(root).ok()
+        FieldElement252::from_hex_be(root)
+            .map(ExpectedPreprocessedRootPolicy::Exact)
+            .map_err(|_| CairoVerificationError::UnsupportedPreprocessedRootConfig)
     }
 }
 
@@ -409,11 +434,13 @@ pub fn verify_cairo_ex<MC: ExpectedPreprocessedRoot>(
             .log_sizes(),
     );
 
-    if let Some(expected_preprocessed_root) = MC::expected_preprocessed_root(
-        preprocessed_trace_variant,
-        pcs_config.fri_config.log_blowup_factor,
-        pcs_config.lifting_log_size,
-    ) {
+    if let ExpectedPreprocessedRootPolicy::Exact(expected_preprocessed_root) =
+        MC::expected_preprocessed_root(
+            preprocessed_trace_variant,
+            pcs_config.fri_config.log_blowup_factor,
+            pcs_config.lifting_log_size,
+        )?
+    {
         if stark_proof.commitments[0] != expected_preprocessed_root {
             return Err(CairoVerificationError::InvalidPreprocessedRoot);
         }
@@ -464,8 +491,100 @@ pub enum CairoVerificationError {
     InvalidLogupSum,
     #[error("Invalid preprocessed commitment root")]
     InvalidPreprocessedRoot,
+    #[error("Unsupported preprocessed root configuration for static root verifier")]
+    UnsupportedPreprocessedRootConfig,
     #[error("Stark verification error: {0}")]
     Stark(#[from] VerificationError),
     #[error("Proof of work verification failed.")]
     ProofOfWork,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expect_exact_blake2s_root(log_blowup_factor: u32) -> Blake2sHash {
+        match Blake2sMerkleChannel::expected_preprocessed_root(
+            PreProcessedTraceVariant::Canonical,
+            log_blowup_factor,
+            None,
+        )
+        .unwrap()
+        {
+            ExpectedPreprocessedRootPolicy::Exact(root) => root,
+            ExpectedPreprocessedRootPolicy::NoStaticRoot => {
+                panic!("expected a static Blake2s root")
+            }
+        }
+    }
+
+    #[test]
+    fn blake2s_canonical_roots_are_defined_for_supported_blowup_factors() {
+        for log_blowup_factor in 1..=5 {
+            let root = expect_exact_blake2s_root(log_blowup_factor);
+            assert_ne!(root, Blake2sHash([0; 32]));
+        }
+    }
+
+    #[test]
+    fn blake2s_canonical_root_policy_fails_closed_for_unsupported_config() {
+        assert!(matches!(
+            Blake2sMerkleChannel::expected_preprocessed_root(
+                PreProcessedTraceVariant::Canonical,
+                6,
+                None,
+            ),
+            Err(CairoVerificationError::UnsupportedPreprocessedRootConfig)
+        ));
+        assert!(matches!(
+            Blake2sMerkleChannel::expected_preprocessed_root(
+                PreProcessedTraceVariant::Canonical,
+                1,
+                Some(26),
+            ),
+            Err(CairoVerificationError::UnsupportedPreprocessedRootConfig)
+        ));
+    }
+
+    #[test]
+    fn poseidon_canonical_without_pedersen_root_policy_fails_closed() {
+        assert!(matches!(
+            Poseidon252MerkleChannel::expected_preprocessed_root(
+                PreProcessedTraceVariant::CanonicalWithoutPedersen,
+                6,
+                None,
+            ),
+            Err(CairoVerificationError::UnsupportedPreprocessedRootConfig)
+        ));
+        assert!(matches!(
+            Poseidon252MerkleChannel::expected_preprocessed_root(
+                PreProcessedTraceVariant::CanonicalWithoutPedersen,
+                1,
+                Some(26),
+            ),
+            Err(CairoVerificationError::UnsupportedPreprocessedRootConfig)
+        ));
+    }
+
+    #[test]
+    fn non_static_root_modes_remain_explicitly_unbound() {
+        assert!(matches!(
+            Blake2sMerkleChannel::expected_preprocessed_root(
+                PreProcessedTraceVariant::CanonicalWithoutPedersen,
+                1,
+                None,
+            )
+            .unwrap(),
+            ExpectedPreprocessedRootPolicy::NoStaticRoot
+        ));
+        assert!(matches!(
+            Blake2sM31MerkleChannel::expected_preprocessed_root(
+                PreProcessedTraceVariant::Canonical,
+                6,
+                Some(26),
+            )
+            .unwrap(),
+            ExpectedPreprocessedRootPolicy::NoStaticRoot
+        ));
+    }
 }

--- a/stwo_cairo_prover/crates/prover/src/prover.rs
+++ b/stwo_cairo_prover/crates/prover/src/prover.rs
@@ -7,7 +7,7 @@ use cairo_air::cairo_components::CairoComponents;
 use cairo_air::claims::{lookup_sum, CairoClaim};
 use cairo_air::relations::CommonLookupElements;
 use cairo_air::utils::{serialize_proof_to_file, ProofFormat};
-use cairo_air::verifier::{verify_cairo_ex, INTERACTION_POW_BITS};
+use cairo_air::verifier::{verify_cairo_ex, ExpectedPreprocessedRoot, INTERACTION_POW_BITS};
 use cairo_air::CairoProof;
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
@@ -50,7 +50,7 @@ mod json {
     pub use sonic_rs::from_str;
 }
 
-fn prove_verify_serialize<MC: MerkleChannel>(
+fn prove_verify_serialize<MC: MerkleChannel + ExpectedPreprocessedRoot>(
     input: ProverInput,
     verify: bool,
     proof_path: &Path,

--- a/stwo_cairo_prover/crates/prover/src/prover.rs
+++ b/stwo_cairo_prover/crates/prover/src/prover.rs
@@ -860,19 +860,22 @@ pub mod tests {
                 verify_cairo::<Blake2sMerkleChannel>(rust_proof.clone()).unwrap();
 
                 let mut wrong_root = rust_proof.clone();
-                wrong_root.stark_proof.commitments[0] =
-                    wrong_root.stark_proof.commitments[1].clone();
+                let mut wrong_root_proof = wrong_root.stark_proof.0.clone();
+                wrong_root_proof.commitments[0] = wrong_root_proof.commitments[1].clone();
+                wrong_root.stark_proof = stwo::core::proof::StarkProof(wrong_root_proof);
                 assert!(matches!(
                     verify_cairo::<Blake2sMerkleChannel>(wrong_root).unwrap_err(),
                     CairoVerificationError::InvalidPreprocessedRoot
                 ));
 
                 let mut unsupported_blowup = rust_proof;
-                unsupported_blowup
-                    .stark_proof
+                let mut unsupported_blowup_proof = unsupported_blowup.stark_proof.0.clone();
+                unsupported_blowup_proof
                     .config
                     .fri_config
                     .log_blowup_factor = 6;
+                unsupported_blowup.stark_proof =
+                    stwo::core::proof::StarkProof(unsupported_blowup_proof);
                 assert!(matches!(
                     verify_cairo::<Blake2sMerkleChannel>(unsupported_blowup).unwrap_err(),
                     CairoVerificationError::UnsupportedPreprocessedRootConfig

--- a/stwo_cairo_prover/crates/prover/src/prover.rs
+++ b/stwo_cairo_prover/crates/prover/src/prover.rs
@@ -577,7 +577,7 @@ pub mod tests {
         use std::io::Write;
         use std::process::Command;
 
-        use cairo_air::verifier::verify_cairo;
+        use cairo_air::verifier::{verify_cairo, CairoVerificationError};
         use cairo_air::CairoProofForRustVerifier;
         use itertools::Itertools;
         use stwo::core::fri::FriConfig;
@@ -856,7 +856,27 @@ pub mod tests {
                 };
                 let cairo_proof =
                     prove_cairo::<Blake2sMerkleChannel>(input, prover_params).unwrap();
-                verify_cairo::<Blake2sMerkleChannel>(cairo_proof.into()).unwrap();
+                let rust_proof: CairoProofForRustVerifier<_> = cairo_proof.into();
+                verify_cairo::<Blake2sMerkleChannel>(rust_proof.clone()).unwrap();
+
+                let mut wrong_root = rust_proof.clone();
+                wrong_root.stark_proof.commitments[0] =
+                    wrong_root.stark_proof.commitments[1].clone();
+                assert!(matches!(
+                    verify_cairo::<Blake2sMerkleChannel>(wrong_root).unwrap_err(),
+                    CairoVerificationError::InvalidPreprocessedRoot
+                ));
+
+                let mut unsupported_blowup = rust_proof;
+                unsupported_blowup
+                    .stark_proof
+                    .config
+                    .fri_config
+                    .log_blowup_factor = 6;
+                assert!(matches!(
+                    verify_cairo::<Blake2sMerkleChannel>(unsupported_blowup).unwrap_err(),
+                    CairoVerificationError::UnsupportedPreprocessedRootConfig
+                ));
             }
 
             #[test]

--- a/stwo_cairo_prover/crates/prover/src/prover.rs
+++ b/stwo_cairo_prover/crates/prover/src/prover.rs
@@ -870,10 +870,7 @@ pub mod tests {
 
                 let mut unsupported_blowup = rust_proof;
                 let mut unsupported_blowup_proof = unsupported_blowup.stark_proof.0.clone();
-                unsupported_blowup_proof
-                    .config
-                    .fri_config
-                    .log_blowup_factor = 6;
+                unsupported_blowup_proof.config.fri_config.log_blowup_factor = 6;
                 unsupported_blowup.stark_proof =
                     stwo::core::proof::StarkProof(unsupported_blowup_proof);
                 assert!(matches!(

--- a/stwo_cairo_prover/crates/prover/src/witness/preprocessed_trace.rs
+++ b/stwo_cairo_prover/crates/prover/src/witness/preprocessed_trace.rs
@@ -106,3 +106,43 @@ fn test_small_canonical_preprocessed_root_regression() {
 
     assert_eq!(root, expected);
 }
+
+#[cfg(feature = "slow-tests")]
+#[test]
+fn static_root_policy_matches_generated_preprocessed_commitments() {
+    use cairo_air::verifier::{ExpectedPreprocessedRoot, ExpectedPreprocessedRootPolicy};
+    use stwo::core::vcs_lifted::blake2_merkle::Blake2sMerkleChannel;
+    use stwo::core::vcs_lifted::poseidon252_merkle::Poseidon252MerkleChannel;
+
+    for log_blowup_factor in 1..=5 {
+        let generated = generate_preprocessed_commitment_root::<Blake2sMerkleChannel>(
+            log_blowup_factor,
+            PreProcessedTraceVariant::Canonical,
+            None,
+        );
+        let expected = Blake2sMerkleChannel::expected_preprocessed_root(
+            PreProcessedTraceVariant::Canonical,
+            log_blowup_factor,
+            None,
+        )
+        .unwrap();
+        assert!(
+            matches!(expected, ExpectedPreprocessedRootPolicy::Exact(root) if root == generated)
+        );
+
+        let generated = generate_preprocessed_commitment_root::<Poseidon252MerkleChannel>(
+            log_blowup_factor,
+            PreProcessedTraceVariant::CanonicalWithoutPedersen,
+            None,
+        );
+        let expected = Poseidon252MerkleChannel::expected_preprocessed_root(
+            PreProcessedTraceVariant::CanonicalWithoutPedersen,
+            log_blowup_factor,
+            None,
+        )
+        .unwrap();
+        assert!(
+            matches!(expected, ExpectedPreprocessedRootPolicy::Exact(root) if root == generated)
+        );
+    }
+}

--- a/stwo_cairo_prover/crates/prover/src/witness/preprocessed_trace.rs
+++ b/stwo_cairo_prover/crates/prover/src/witness/preprocessed_trace.rs
@@ -146,3 +146,37 @@ fn static_root_policy_matches_generated_preprocessed_commitments() {
         );
     }
 }
+
+#[cfg(feature = "slow-tests")]
+#[test]
+fn static_root_policy_matches_generated_preprocessed_commitments_log_1() {
+    use cairo_air::verifier::{ExpectedPreprocessedRoot, ExpectedPreprocessedRootPolicy};
+    use stwo::core::vcs_lifted::blake2_merkle::Blake2sMerkleChannel;
+    use stwo::core::vcs_lifted::poseidon252_merkle::Poseidon252MerkleChannel;
+
+    let generated = generate_preprocessed_commitment_root::<Blake2sMerkleChannel>(
+        1,
+        PreProcessedTraceVariant::Canonical,
+        None,
+    );
+    let expected = Blake2sMerkleChannel::expected_preprocessed_root(
+        PreProcessedTraceVariant::Canonical,
+        1,
+        None,
+    )
+    .unwrap();
+    assert!(matches!(expected, ExpectedPreprocessedRootPolicy::Exact(root) if root == generated));
+
+    let generated = generate_preprocessed_commitment_root::<Poseidon252MerkleChannel>(
+        1,
+        PreProcessedTraceVariant::CanonicalWithoutPedersen,
+        None,
+    );
+    let expected = Poseidon252MerkleChannel::expected_preprocessed_root(
+        PreProcessedTraceVariant::CanonicalWithoutPedersen,
+        1,
+        None,
+    )
+    .unwrap();
+    assert!(matches!(expected, ExpectedPreprocessedRootPolicy::Exact(root) if root == generated));
+}

--- a/stwo_cairo_prover/crates/prover/src/witness/preprocessed_trace.rs
+++ b/stwo_cairo_prover/crates/prover/src/witness/preprocessed_trace.rs
@@ -146,37 +146,3 @@ fn static_root_policy_matches_generated_preprocessed_commitments() {
         );
     }
 }
-
-#[cfg(feature = "slow-tests")]
-#[test]
-fn static_root_policy_matches_generated_preprocessed_commitments_log_1() {
-    use cairo_air::verifier::{ExpectedPreprocessedRoot, ExpectedPreprocessedRootPolicy};
-    use stwo::core::vcs_lifted::blake2_merkle::Blake2sMerkleChannel;
-    use stwo::core::vcs_lifted::poseidon252_merkle::Poseidon252MerkleChannel;
-
-    let generated = generate_preprocessed_commitment_root::<Blake2sMerkleChannel>(
-        1,
-        PreProcessedTraceVariant::Canonical,
-        None,
-    );
-    let expected = Blake2sMerkleChannel::expected_preprocessed_root(
-        PreProcessedTraceVariant::Canonical,
-        1,
-        None,
-    )
-    .unwrap();
-    assert!(matches!(expected, ExpectedPreprocessedRootPolicy::Exact(root) if root == generated));
-
-    let generated = generate_preprocessed_commitment_root::<Poseidon252MerkleChannel>(
-        1,
-        PreProcessedTraceVariant::CanonicalWithoutPedersen,
-        None,
-    );
-    let expected = Poseidon252MerkleChannel::expected_preprocessed_root(
-        PreProcessedTraceVariant::CanonicalWithoutPedersen,
-        1,
-        None,
-    )
-    .unwrap();
-    assert!(matches!(expected, ExpectedPreprocessedRootPolicy::Exact(root) if root == generated));
-}


### PR DESCRIPTION
Fixes #1793

## Summary

The Rust verifier now checks proof-supplied preprocessed commitments against verifier-known expected roots before committing them into the transcript.

The check is applied for the Cairo verifier's static root policies:
- Blake2s canonical preprocessed traces without lifting
- Poseidon canonical-without-pedersen preprocessed traces without lifting

Other proof modes keep the existing behavior until their verifier-bound root tables are available.

## Soundness

The preprocessed trace root is verifier-selected data, not prover-selected proof data. Checking the expected root before PCS commitment keeps the Rust verifier aligned with the Cairo verifier's transcript binding policy.

## Testing

- `git diff --check`
- Targeted source review against the Cairo hard-coded root tables and verifier commit order

No local compile or test run; verification should run in CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1794)
<!-- Reviewable:end -->
