### PR TITLE
verifier_core: consolidate interaction errors into VerificationError

### DIFF
--- a/stwo_cairo_verifier/crates/cairo_air/src/lib.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/lib.cairo
@@ -45,7 +45,7 @@ use stwo_verifier_core::fields::qm31::{PackedUnreducedQM31, PackedUnreducedQM31T
 use stwo_verifier_core::pcs::PcsConfigTrait;
 use stwo_verifier_core::pcs::verifier::{CommitmentSchemeVerifierImpl, get_trace_lde_log_size};
 use stwo_verifier_core::utils::{ArrayImpl, OptionImpl, pack_into_qm31s, pow2};
-use stwo_verifier_core::verifier::{StarkProof, verify};
+use stwo_verifier_core::verifier::{StarkProof, VerificationError, verify};
 use stwo_verifier_utils::{MemorySection, PubMemoryValue, construct_f252};
 use crate::components::memory_address_to_id::*;
 use crate::components::memory_id_to_big::*;
@@ -226,7 +226,7 @@ pub fn verify_cairo(proof: CairoProof) {
     assert!(
         channel.verify_pow_nonce(INTERACTION_POW_BITS, interaction_pow),
         "{}",
-        CairoVerificationError::InteractionProofOfWork,
+        VerificationError::InteractionProofOfWork,
     );
     channel.mix_u64(interaction_pow);
 
@@ -234,7 +234,7 @@ pub fn verify_cairo(proof: CairoProof) {
     assert!(
         lookup_sum(@claim, @common_lookup_elements, @interaction_claim).is_zero(),
         "{}",
-        CairoVerificationError::InvalidLogupSum,
+        VerificationError::InvalidLogupSum,
     );
 
     interaction_claim.mix_into(ref channel);
@@ -934,24 +934,5 @@ impl CasmStateImpl of CasmStateTrait {
         channel.mix_u64(pc_u32.into());
         channel.mix_u64(ap_u32.into());
         channel.mix_u64(fp_u32.into());
-    }
-}
-
-#[derive(Drop, Debug)]
-pub enum CairoVerificationError {
-    InteractionProofOfWork,
-    InvalidLogupSum,
-}
-
-impl CairoVerificationErrorDisplay of core::fmt::Display<CairoVerificationError> {
-    fn fmt(
-        self: @CairoVerificationError, ref f: core::fmt::Formatter,
-    ) -> Result<(), core::fmt::Error> {
-        match self {
-            CairoVerificationError::InteractionProofOfWork => write!(
-                f, "Interaction Proof Of Work",
-            ),
-            CairoVerificationError::InvalidLogupSum => write!(f, "Logup sum is not zero"),
-        }
     }
 }

--- a/stwo_cairo_verifier/crates/verifier_core/src/verifier.cairo
+++ b/stwo_cairo_verifier/crates/verifier_core/src/verifier.cairo
@@ -164,6 +164,10 @@ pub enum VerificationError {
     OodsNotMatching,
     /// Security bits are too low.
     SecurityBitsTooLow,
+    /// Interaction proof of work verification failed.
+    InteractionProofOfWork,
+    /// The logup sum is not zero.
+    InvalidLogupSum,
 }
 
 impl VerificationErrorDisplay of core::fmt::Display<VerificationError> {
@@ -172,9 +176,13 @@ impl VerificationErrorDisplay of core::fmt::Display<VerificationError> {
             VerificationError::InvalidStructure(error) => write!(
                 f, "Proof has invalid structure: {}", error,
             ),
-            VerificationError::QueriesProofOfWork => write!(f, "Proof of work verification failed"),
+            VerificationError::QueriesProofOfWork => write!(f, "Proof Of Work verification failed"),
             VerificationError::OodsNotMatching => write!(f, "Invalid OODS eval"),
             VerificationError::SecurityBitsTooLow => write!(f, "Security bits are too low"),
+            VerificationError::InteractionProofOfWork => write!(
+                f, "Interaction Proof Of Work verification failed",
+            ),
+            VerificationError::InvalidLogupSum => write!(f, "Logup sum is not zero"),
         }
     }
 }


### PR DESCRIPTION
Move InteractionProofOfWork and InvalidLogupSum from the cairo_air-local
CairoVerificationError enum into the shared verifier_core::VerificationError,
and update verify_cairo to use them.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1795)
<!-- Reviewable:end -->
