### PR TITLE
circuit_air: add claim log-size and relation-use derivation

### DIFF
--- a/stwo_cairo_verifier/Scarb.lock
+++ b/stwo_cairo_verifier/Scarb.lock
@@ -36,6 +36,7 @@ dependencies = [
  "bounded_int",
  "stwo_constraint_framework",
  "stwo_verifier_core",
+ "stwo_verifier_utils",
 ]
 
 [[package]]

--- a/stwo_cairo_verifier/crates/circuit_air/Scarb.toml
+++ b/stwo_cairo_verifier/crates/circuit_air/Scarb.toml
@@ -21,6 +21,7 @@ cairo-lint.workspace = true
 bounded_int = { path = "../bounded_int" }
 stwo_verifier_core = { path = "../verifier_core" }
 stwo_constraint_framework = { path = "../constraint_framework" }
+stwo_verifier_utils = { path = "../verifier_utils" }
 
 [dev-dependencies]
 cairo_test = "2.12.2"

--- a/stwo_cairo_verifier/crates/circuit_air/src/claims.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/claims.cairo
@@ -1,8 +1,21 @@
-use stwo_constraint_framework::{CommonLookupElements, LookupElementsTrait};
+use stwo_constraint_framework::{
+    CommonLookupElements, LookupElementsTrait, RelationUsesDict, accumulate_relation_uses,
+};
+use stwo_verifier_core::TreeArray;
 use stwo_verifier_core::channel::{Channel, ChannelTrait};
 use stwo_verifier_core::fields::qm31::{QM31, QM31Serde, QM31Trait};
-use crate::component_indices::N_COMPONENTS;
+use stwo_verifier_utils::zip_eq::zip_eq;
+use crate::component_indices::{
+    BLAKE_G_GATE_COMPONENT_IDX, EQ_COMPONENT_IDX, M_31_TO_U_32_COMPONENT_IDX, N_COMPONENTS,
+    N_INTERACTION_COLUMNS_PER_COMPONENT, N_TRACE_COLUMNS_PER_COMPONENT, QM31_OPS_COMPONENT_IDX,
+    TRIPLE_XOR_COMPONENT_IDX,
+};
+use crate::components;
 use crate::prelude::{Invertible, M31, Zero, m31};
+use crate::preprocessed_columns::{
+    BLAKE_G_GATE_INPUT_ADDR_A_IDX, EQ_IN0_ADDRESS_IDX, M_31_TO_U_32_INPUT_ADDR_IDX, OP_0_ADDR_IDX,
+    TRIPLE_XOR_INPUT_ADDR_0_IDX,
+};
 use crate::relations::GATE_RELATION_ID;
 
 /// Variable index of the public input `u`.
@@ -90,4 +103,76 @@ pub fn lookup_sum(
     }
 
     component_sum + u_sum + output_sum
+}
+
+/// Derives each component's log size from the preprocessed column log sizes (supplied by the
+/// verifier config). variable-size components read the log size of one of their preprocessed
+/// columns (all columns of a component share its log size), and fixed-size components return their
+/// `LOG_SIZE` constant. Indexed by COMPONENT_IDX.
+pub fn derive_component_log_sizes(preprocessed_column_log_sizes: Span<u32>) -> [u32; N_COMPONENTS] {
+    [
+        *preprocessed_column_log_sizes.at(EQ_IN0_ADDRESS_IDX),
+        *preprocessed_column_log_sizes.at(OP_0_ADDR_IDX),
+        *preprocessed_column_log_sizes.at(TRIPLE_XOR_INPUT_ADDR_0_IDX),
+        *preprocessed_column_log_sizes.at(M_31_TO_U_32_INPUT_ADDR_IDX),
+        *preprocessed_column_log_sizes.at(BLAKE_G_GATE_INPUT_ADDR_A_IDX),
+        components::verify_bitwise_xor_8::LOG_SIZE, components::verify_bitwise_xor_12::LOG_SIZE,
+        components::verify_bitwise_xor_4::LOG_SIZE, components::verify_bitwise_xor_7::LOG_SIZE,
+        components::verify_bitwise_xor_9::LOG_SIZE, components::range_check_16::LOG_SIZE,
+    ]
+}
+
+/// Builds `[preprocessed (empty placeholder), trace, interaction]` column log sizes from the
+/// per-component log sizes, repeating each component's log size by its trace/interaction column
+/// count, in COMPONENT_IDX order. The preprocessed placeholder is discarded by the caller, which
+/// commits the preprocessed tree using the hardcoded `PREPROCESSED_COLUMN_LOG_SIZES`.
+pub fn column_log_sizes_per_tree(component_log_sizes: [u32; N_COMPONENTS]) -> TreeArray<Span<u32>> {
+    let mut trace_log_sizes = array![];
+    let mut interaction_log_sizes = array![];
+    for (log_size, (n_trace, n_interaction)) in zip_eq(
+        component_log_sizes.span(),
+        zip_eq(N_TRACE_COLUMNS_PER_COMPONENT.span(), N_INTERACTION_COLUMNS_PER_COMPONENT.span()),
+    ) {
+        for _ in 0..*n_trace {
+            trace_log_sizes.append(*log_size);
+        }
+        for _ in 0..*n_interaction {
+            interaction_log_sizes.append(*log_size);
+        }
+    }
+    array![array![].span(), trace_log_sizes.span(), interaction_log_sizes.span()]
+}
+
+/// Accumulates lookup-relation uses across components from the derived per-component log sizes.
+/// Only the variable-size components export `RELATION_USES_PER_ROW`; fixed-size components
+/// (lookup tables) use no relations.
+pub fn accumulate_circuit_relation_uses(
+    component_log_sizes: [u32; N_COMPONENTS], ref relation_uses: RelationUsesDict,
+) {
+    let log_sizes = component_log_sizes.span();
+    accumulate_relation_uses(
+        ref relation_uses,
+        components::eq::RELATION_USES_PER_ROW.span(),
+        *log_sizes.at(EQ_COMPONENT_IDX),
+    );
+    accumulate_relation_uses(
+        ref relation_uses,
+        components::qm31_ops::RELATION_USES_PER_ROW.span(),
+        *log_sizes.at(QM31_OPS_COMPONENT_IDX),
+    );
+    accumulate_relation_uses(
+        ref relation_uses,
+        components::triple_xor::RELATION_USES_PER_ROW.span(),
+        *log_sizes.at(TRIPLE_XOR_COMPONENT_IDX),
+    );
+    accumulate_relation_uses(
+        ref relation_uses,
+        components::m_31_to_u_32::RELATION_USES_PER_ROW.span(),
+        *log_sizes.at(M_31_TO_U_32_COMPONENT_IDX),
+    );
+    accumulate_relation_uses(
+        ref relation_uses,
+        components::blake_g_gate::RELATION_USES_PER_ROW.span(),
+        *log_sizes.at(BLAKE_G_GATE_COMPONENT_IDX),
+    );
 }


### PR DESCRIPTION
Add derive_component_log_sizes, column_log_sizes_per_tree, and
accumulate_circuit_relation_uses to claims.cairo, deriving per-component
log sizes from the preprocessed column log sizes and accumulating
lookup-relation uses for the claim check.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1797)
<!-- Reviewable:end -->
