### PR TITLE
Bump stwo to 74951f79

### DIFF
--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -3531,7 +3531,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "stwo"
 version = "2.2.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=02e5ae3e#02e5ae3ea2e659f80830595afa88c81dd278ab5e"
+source = "git+https://github.com/starkware-libs/stwo?rev=74951f79#74951f7945b3f5d3fa54cc43ee73ac027146227a"
 dependencies = [
  "blake2",
  "blake3",
@@ -3560,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "stwo-air-utils"
 version = "2.2.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=02e5ae3e#02e5ae3ea2e659f80830595afa88c81dd278ab5e"
+source = "git+https://github.com/starkware-libs/stwo?rev=74951f79#74951f7945b3f5d3fa54cc43ee73ac027146227a"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -3572,7 +3572,7 @@ dependencies = [
 [[package]]
 name = "stwo-air-utils-derive"
 version = "2.2.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=02e5ae3e#02e5ae3ea2e659f80830595afa88c81dd278ab5e"
+source = "git+https://github.com/starkware-libs/stwo?rev=74951f79#74951f7945b3f5d3fa54cc43ee73ac027146227a"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -3725,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "stwo-constraint-framework"
 version = "2.2.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=02e5ae3e#02e5ae3ea2e659f80830595afa88c81dd278ab5e"
+source = "git+https://github.com/starkware-libs/stwo?rev=74951f79#74951f7945b3f5d3fa54cc43ee73ac027146227a"
 dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.12.1",

--- a/stwo_cairo_prover/Cargo.toml
+++ b/stwo_cairo_prover/Cargo.toml
@@ -55,10 +55,10 @@ stwo-cairo-common = { path = "crates/common", version = "~1.2.2" }
 cairo-air = { path = "crates/cairo-air", version = "~1.2.2" }
 stwo-cairo-serialize = { path = "crates/cairo-serialize", version = "~1.2.2" }
 stwo-cairo-serialize-derive = { path = "crates/cairo-serialize-derive", version = "~1.2.2" }
-stwo = { git = "https://github.com/starkware-libs/stwo", rev = "02e5ae3e" }
-stwo-constraint-framework = { git = "https://github.com/starkware-libs/stwo", rev = "02e5ae3e" }
-stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "02e5ae3e" }
-stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "02e5ae3e" }
+stwo = { git = "https://github.com/starkware-libs/stwo", rev = "74951f79" }
+stwo-constraint-framework = { git = "https://github.com/starkware-libs/stwo", rev = "74951f79" }
+stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "74951f79" }
+stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "74951f79" }
 test-case = "3.3.1"
 thiserror = { version = "2.0.12", default-features = false }
 tracing = "0.1.40"


### PR DESCRIPTION
Bump stwo dependencies to `74951f79`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1802)
<!-- Reviewable:end -->
