### PR TITLE
Expose warm_pedersen_pp_trace as pub

### DIFF
--- a/stwo_cairo_prover/crates/prover/src/prover.rs
+++ b/stwo_cairo_prover/crates/prover/src/prover.rs
@@ -79,7 +79,7 @@ where
 /// The table is a `LazyLock` whose initializer itself uses rayon. Forcing it before the parallel
 /// witness generation avoids a deadlock: if first built from within that section, the worker pool
 /// is exhausted and the initializer can't get the threads it needs to finish.
-pub(crate) fn warm_pedersen_pp_trace(variant: PreProcessedTraceVariant) {
+pub fn warm_pedersen_pp_trace(variant: PreProcessedTraceVariant) {
     match variant {
         PreProcessedTraceVariant::Canonical => {
             LazyLock::force(&PEDERSEN_TABLE_18);


### PR DESCRIPTION
`prove_cairo_with_precompute` does not warm the Pedersen points table itself — callers driving the precompute path materialize the preprocessed trace (`gen_trace`) on their own, and `PreProcessedColumn::get_data` panics if the table is read before being force-loaded (added in #1805).

This makes `warm_pedersen_pp_trace` `pub` so those callers can warm the table before `gen_trace` and the parallel witness generation.

## Motivation
proving-utils' recursive prover sets up its precomputes by calling `gen_trace` directly (outside `generate_preprocessed_commitment_root`), then proves via `prove_cairo_with_precompute`. With #1805 merged, that `gen_trace` now panics (`require_initialized`) because nothing warms the table first, and `prove_cairo_with_precompute` no longer self-warms. Exposing this function lets the precompute setup warm the table once, up front.

Pure visibility change (`pub(crate)` → `pub`) plus a doc note; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1806)
<!-- Reviewable:end -->
