### PR TITLE
Bump the stwo dependency.

### DIFF
--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -3525,7 +3525,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 [[package]]
 name = "stwo"
 version = "2.2.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=74951f79#74951f7945b3f5d3fa54cc43ee73ac027146227a"
+source = "git+https://github.com/starkware-libs/stwo?rev=5ea05973#5ea059737572b7c94331ce4f0caeb19e063fa74f"
 dependencies = [
  "blake2",
  "blake3",
@@ -3554,7 +3554,7 @@ dependencies = [
 [[package]]
 name = "stwo-air-utils"
 version = "2.2.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=74951f79#74951f7945b3f5d3fa54cc43ee73ac027146227a"
+source = "git+https://github.com/starkware-libs/stwo?rev=5ea05973#5ea059737572b7c94331ce4f0caeb19e063fa74f"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -3566,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "stwo-air-utils-derive"
 version = "2.2.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=74951f79#74951f7945b3f5d3fa54cc43ee73ac027146227a"
+source = "git+https://github.com/starkware-libs/stwo?rev=5ea05973#5ea059737572b7c94331ce4f0caeb19e063fa74f"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -3719,7 +3719,7 @@ dependencies = [
 [[package]]
 name = "stwo-constraint-framework"
 version = "2.2.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=74951f79#74951f7945b3f5d3fa54cc43ee73ac027146227a"
+source = "git+https://github.com/starkware-libs/stwo?rev=5ea05973#5ea059737572b7c94331ce4f0caeb19e063fa74f"
 dependencies = [
  "hashbrown 0.15.5",
  "itertools 0.12.1",

--- a/stwo_cairo_prover/Cargo.toml
+++ b/stwo_cairo_prover/Cargo.toml
@@ -55,10 +55,10 @@ stwo-cairo-common = { path = "crates/common", version = "~1.2.2" }
 cairo-air = { path = "crates/cairo-air", version = "~1.2.2" }
 stwo-cairo-serialize = { path = "crates/cairo-serialize", version = "~1.2.2" }
 stwo-cairo-serialize-derive = { path = "crates/cairo-serialize-derive", version = "~1.2.2" }
-stwo = { git = "https://github.com/starkware-libs/stwo", rev = "74951f79" }
-stwo-constraint-framework = { git = "https://github.com/starkware-libs/stwo", rev = "74951f79" }
-stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "74951f79" }
-stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "74951f79" }
+stwo = { git = "https://github.com/starkware-libs/stwo", rev = "5ea05973" }
+stwo-constraint-framework = { git = "https://github.com/starkware-libs/stwo", rev = "5ea05973" }
+stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "5ea05973" }
+stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "5ea05973" }
 test-case = "3.3.1"
 thiserror = { version = "2.0.12", default-features = false }
 tracing = "0.1.40"

--- a/stwo_cairo_prover/crates/dev_utils/src/bin/verify.rs
+++ b/stwo_cairo_prover/crates/dev_utils/src/bin/verify.rs
@@ -5,7 +5,7 @@ use cairo_air::verifier::verify_cairo;
 use cairo_air::CairoProofForRustVerifier;
 use clap::Parser;
 use stwo::core::vcs_lifted::blake2_merkle::{
-    Blake2sM31MerkleChannel, Blake2sM31MerkleHasher, Blake2sMerkleChannel, Blake2sMerkleHasher,
+    Blake2sM31MerkleChannel, Blake2sMerkleChannel, Blake2sMerkleHasher,
 };
 use stwo::core::vcs_lifted::poseidon252_merkle::{
     Poseidon252MerkleChannel, Poseidon252MerkleHasher,
@@ -50,7 +50,7 @@ fn verify_blake2s_proof(proof: String) -> Result<()> {
 }
 
 fn verify_blake2s_m31_proof(proof: String) -> Result<()> {
-    let proof: CairoProofForRustVerifier<Blake2sM31MerkleHasher> = sonic_rs::from_str(&proof)?;
+    let proof: CairoProofForRustVerifier<Blake2sMerkleHasher> = sonic_rs::from_str(&proof)?;
     verify_cairo::<Blake2sM31MerkleChannel>(proof)?;
     Ok(())
 }


### PR DESCRIPTION
In the new revision, Blake2sM31MerkleChannel uses Blake2sMerkleHasher as its hasher instead of Blake2sM31MerkleHasher, and produces proof with unreduced blake2s hashes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1808)
<!-- Reviewable:end -->
