### PR TITLE
Prepare crates for crates.io publishing (v1.3.0)

### DIFF
--- a/stwo_cairo_prover/Cargo.toml
+++ b/stwo_cairo_prover/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/starkware-libs/stwo-cairo"
@@ -48,17 +48,17 @@ starknet-types-core = { version = "=0.2.4", features = [
     "curve",
     "num-traits",
 ] }
-stwo-cairo-prover = { path = "crates/prover", version = "~1.2.2" }
-stwo-cairo-utils = { path = "crates/utils", version = "~1.2.2" }
-stwo-cairo-adapter = { path = "crates/adapter", version = "~1.2.2" }
-stwo-cairo-common = { path = "crates/common", version = "~1.2.2" }
-cairo-air = { path = "crates/cairo-air", version = "~1.2.2" }
-stwo-cairo-serialize = { path = "crates/cairo-serialize", version = "~1.2.2" }
-stwo-cairo-serialize-derive = { path = "crates/cairo-serialize-derive", version = "~1.2.2" }
-stwo = { git = "https://github.com/starkware-libs/stwo", rev = "74951f79" }
-stwo-constraint-framework = { git = "https://github.com/starkware-libs/stwo", rev = "74951f79" }
-stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "74951f79" }
-stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "74951f79" }
+stwo-cairo-prover = { path = "crates/prover", version = "~1.3.0" }
+stwo-cairo-utils = { path = "crates/utils", version = "~1.3.0" }
+stwo-cairo-adapter = { path = "crates/adapter", version = "~1.3.0" }
+stwo-cairo-common = { path = "crates/common", version = "~1.3.0" }
+cairo-air = { path = "crates/cairo-air", version = "~1.3.0" }
+stwo-cairo-serialize = { path = "crates/cairo-serialize", version = "~1.3.0" }
+stwo-cairo-serialize-derive = { path = "crates/cairo-serialize-derive", version = "~1.3.0" }
+stwo = { version = "2.3.0" }
+stwo-constraint-framework = { version = "2.3.0" }
+stwo-air-utils-derive = { version = "2.3.0" }
+stwo-air-utils = { version = "2.3.0" }
 test-case = "3.3.1"
 thiserror = { version = "2.0.12", default-features = false }
 tracing = "0.1.40"

--- a/stwo_cairo_prover/crates/adapter/Cargo.toml
+++ b/stwo_cairo_prover/crates/adapter/Cargo.toml
@@ -19,7 +19,7 @@ itertools.workspace = true
 log.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-stwo-cairo-common = { path = "../common", version = "~1.2.2" }
+stwo-cairo-common = { path = "../common", version = "~1.3.0" }
 tracing.workspace = true
 thiserror.workspace = true
 stwo.workspace = true

--- a/stwo_cairo_prover/crates/cairo-air/Cargo.toml
+++ b/stwo_cairo_prover/crates/cairo-air/Cargo.toml
@@ -18,13 +18,13 @@ log.workspace = true
 num-traits.workspace = true
 paste.workspace = true
 # TODO(Ohad): Add parallel config.
-stwo-cairo-common = { path = "../common", version = "~1.2.2" }
+stwo-cairo-common = { path = "../common", version = "~1.3.0" }
 rayon.workspace = true
 serde.workspace = true
 starknet-curve.workspace = true
 starknet-ff.workspace = true
 starknet-types-core.workspace = true
-stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.2.2" }
+stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.3.0" }
 stwo.workspace = true
 stwo-constraint-framework.workspace = true
 thiserror.workspace = true

--- a/stwo_cairo_prover/crates/cairo-serialize/Cargo.toml
+++ b/stwo_cairo_prover/crates/cairo-serialize/Cargo.toml
@@ -8,5 +8,5 @@ description = "Serialization utilities for Stwo Cairo proofs"
 
 [dependencies]
 starknet-ff.workspace = true
-stwo-cairo-serialize-derive = { path = "../cairo-serialize-derive", version = "~1.2.2" }
+stwo-cairo-serialize-derive = { path = "../cairo-serialize-derive", version = "~1.3.0" }
 stwo.workspace = true

--- a/stwo_cairo_prover/crates/common/Cargo.toml
+++ b/stwo_cairo_prover/crates/common/Cargo.toml
@@ -16,7 +16,7 @@ ruint.workspace = true
 serde.workspace = true
 starknet-ff.workspace = true
 starknet-types-core.workspace = true
-stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.2.2" }
+stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.3.0" }
 stwo.workspace = true
 stwo-constraint-framework.workspace = true
 serde_arrays.workspace = true

--- a/stwo_cairo_prover/crates/dev_utils/Cargo.toml
+++ b/stwo_cairo_prover/crates/dev_utils/Cargo.toml
@@ -12,15 +12,15 @@ required-features = ["stwo-cairo-adapter/extract-mem-trace"]
 
 [dependencies]
 anyhow.workspace = true
-cairo-air = { path = "../cairo-air", version = "~1.2.2" }
+cairo-air = { path = "../cairo-air", version = "~1.3.0" }
 clap.workspace = true
 serde.workspace = true
 starknet-ff.workspace = true
 sonic-rs.workspace = true
-stwo-cairo-adapter = { path = "../adapter", version = "~1.2.2" }
-stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.2.2" }
+stwo-cairo-adapter = { path = "../adapter", version = "~1.3.0" }
+stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.3.0" }
 stwo.workspace = true
-stwo-cairo-prover = { path = "../prover", version = "~1.2.2" }
+stwo-cairo-prover = { path = "../prover", version = "~1.3.0" }
 tracing-subscriber.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/stwo_cairo_prover/crates/prover/Cargo.toml
+++ b/stwo_cairo_prover/crates/prover/Cargo.toml
@@ -23,8 +23,8 @@ itertools.workspace = true
 num-traits.workspace = true
 paste.workspace = true
 # TODO(Ohad): Add parallel config.
-stwo-cairo-common = { path = "../common", version = "~1.2.2", features = ["prover"] }
-stwo-cairo-adapter = { path = "../adapter", version = "~1.2.2" }
+stwo-cairo-common = { path = "../common", version = "~1.3.0", features = ["prover"] }
+stwo-cairo-adapter = { path = "../adapter", version = "~1.3.0" }
 rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -32,8 +32,8 @@ anyhow.workspace = true
 starknet-curve.workspace = true
 starknet-ff.workspace = true
 starknet-types-core.workspace = true
-stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.2.2" }
-cairo-air = { path = "../cairo-air", version = "~1.2.2" }
+stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.3.0" }
+cairo-air = { path = "../cairo-air", version = "~1.3.0" }
 stwo = { workspace = true, features = ["parallel", "prover"] }
 stwo-constraint-framework = { workspace = true, features = ["parallel", "prover"] }
 tracing.workspace = true


### PR DESCRIPTION
## Summary
Prepares the stwo-cairo workspace crates for publishing **v1.3.0** to crates.io.

- Bumps the workspace version to **1.3.0**.
- Switches the stwo dependencies from `git` revs to published version requirements: `stwo = "2.3.0"` (+ `constraint-framework`, `air-utils-derive`, `air-utils`).
- Crate metadata (description/license/repository) was already complete.

### Version rationale
Minor (feature-additive) bump over 1.2.2 — 61 commits since `v1.2.2`: new `circuit_air` crate skeleton + components, AIR regeneration, API changes, and the stwo bump.

## ⚠️ Depends on stwo 2.3.0
The stwo deps now point at registry `2.3.0`, so **stwo 2.3.0 must be published first** before this workspace can resolve and `Cargo.lock` can be regenerated.

> **Base branch note:** targets `gil/expose-warm-pedersen-pp-trace`, the branch these changes were authored on.

Publish order within this workspace: `stwo-cairo-serialize-derive → stwo-cairo-serialize → stwo-cairo-common → cairo-air → stwo-cairo-adapter → stwo-cairo-prover → stwo-cairo-utils`.

Second link in the chain: stwo 2.3.0 → **stwo-cairo 1.3.0** → stwo-circuits 1.0.0 → proving-utils privacy crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1809)
<!-- Reviewable:end -->
