### PR TITLE
Prepare crates for crates.io publishing v1.3.0 (v0.14.3-rust-bump snapshot)

### DIFF
--- a/.github/workflows/cairo-ci.yaml
+++ b/.github/workflows/cairo-ci.yaml
@@ -9,7 +9,7 @@ on:
       - checks_requested
 
 env:
-  NIGHTLY_VERSION: "nightly-2025-06-23"
+  NIGHTLY_VERSION: "nightly-2026-01-15"
   STABLE_VERSION: "1.89.0"
 
 jobs:

--- a/stwo_cairo_prover/Cargo.lock
+++ b/stwo_cairo_prover/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-air"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "bincode 1.3.3",
  "bzip2",
@@ -1849,7 +1849,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -3371,8 +3370,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "stwo"
-version = "2.2.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=489a0f3e#489a0f3ee44a59e03944ad9aa4f3e5a91a3d3f08"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f36868631bb04ea97ad0f42daef676f87496edba200c80b24f8b6731352c3c"
 dependencies = [
  "blake2",
  "blake3",
@@ -3381,7 +3381,7 @@ dependencies = [
  "dashmap",
  "educe 0.5.11",
  "fnv",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hex",
  "indexmap",
  "itertools 0.12.1",
@@ -3399,8 +3399,9 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils"
-version = "2.2.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=489a0f3e#489a0f3ee44a59e03944ad9aa4f3e5a91a3d3f08"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f60480c80a27ec979022a679e50f09b22ac892298eac039e5dfb0031107413"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -3411,8 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "stwo-air-utils-derive"
-version = "2.2.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=489a0f3e#489a0f3ee44a59e03944ad9aa4f3e5a91a3d3f08"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70cadfd1768f7a1f34ed48a9e57c9f083938c5359f3465732f296cea8ed14aad"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -3422,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-cairo-adapter"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
@@ -3450,7 +3452,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-cairo-common"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "bytemuck",
  "itertools 0.12.1",
@@ -3469,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-cairo-dev-utils"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -3498,7 +3500,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-cairo-prover"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3537,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-cairo-serialize"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "starknet-ff",
  "stwo",
@@ -3546,7 +3548,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-cairo-serialize-derive"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -3554,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "stwo-cairo-utils"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "env_logger",
  "log",
@@ -3564,10 +3566,11 @@ dependencies = [
 
 [[package]]
 name = "stwo-constraint-framework"
-version = "2.2.0"
-source = "git+https://github.com/starkware-libs/stwo?rev=489a0f3e#489a0f3ee44a59e03944ad9aa4f3e5a91a3d3f08"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f42067540d13760ad11b949d0a28a3faf02d17087eff15bc95ef573e6e95f5b"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "itertools 0.12.1",
  "num-traits",
  "rand 0.8.5",

--- a/stwo_cairo_prover/Cargo.toml
+++ b/stwo_cairo_prover/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.2"
+version = "1.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/starkware-libs/stwo-cairo"
@@ -48,17 +48,17 @@ starknet-types-core = { version = "=0.2.4", features = [
     "curve",
     "num-traits",
 ] }
-stwo-cairo-prover = { path = "crates/prover", version = "~1.2.2" }
-stwo-cairo-utils = { path = "crates/utils", version = "~1.2.2" }
-stwo-cairo-adapter = { path = "crates/adapter", version = "~1.2.2" }
-stwo-cairo-common = { path = "crates/common", version = "~1.2.2" }
-cairo-air = { path = "crates/cairo-air", version = "~1.2.2" }
-stwo-cairo-serialize = { path = "crates/cairo-serialize", version = "~1.2.2" }
-stwo-cairo-serialize-derive = { path = "crates/cairo-serialize-derive", version = "~1.2.2" }
-stwo = { git = "https://github.com/starkware-libs/stwo", rev = "489a0f3e" }
-stwo-constraint-framework = { git = "https://github.com/starkware-libs/stwo", rev = "489a0f3e" }
-stwo-air-utils-derive = { git = "https://github.com/starkware-libs/stwo", rev = "489a0f3e" }
-stwo-air-utils = { git = "https://github.com/starkware-libs/stwo", rev = "489a0f3e" }
+stwo-cairo-prover = { path = "crates/prover", version = "~1.3.0" }
+stwo-cairo-utils = { path = "crates/utils", version = "~1.3.0" }
+stwo-cairo-adapter = { path = "crates/adapter", version = "~1.3.0" }
+stwo-cairo-common = { path = "crates/common", version = "~1.3.0" }
+cairo-air = { path = "crates/cairo-air", version = "~1.3.0" }
+stwo-cairo-serialize = { path = "crates/cairo-serialize", version = "~1.3.0" }
+stwo-cairo-serialize-derive = { path = "crates/cairo-serialize-derive", version = "~1.3.0" }
+stwo = { version = "2.3.0" }
+stwo-constraint-framework = { version = "2.3.0" }
+stwo-air-utils-derive = { version = "2.3.0" }
+stwo-air-utils = { version = "2.3.0" }
 test-case = "3.3.1"
 thiserror = { version = "2.0.12", default-features = false }
 tracing = "0.1.40"

--- a/stwo_cairo_prover/crates/adapter/Cargo.toml
+++ b/stwo_cairo_prover/crates/adapter/Cargo.toml
@@ -19,7 +19,7 @@ itertools.workspace = true
 log.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-stwo-cairo-common = { path = "../common", version = "~1.2.2" }
+stwo-cairo-common = { path = "../common", version = "~1.3.0" }
 tracing.workspace = true
 thiserror.workspace = true
 stwo.workspace = true

--- a/stwo_cairo_prover/crates/cairo-air/Cargo.toml
+++ b/stwo_cairo_prover/crates/cairo-air/Cargo.toml
@@ -18,13 +18,13 @@ log.workspace = true
 num-traits.workspace = true
 paste.workspace = true
 # TODO(Ohad): Add parallel config.
-stwo-cairo-common = { path = "../common", version = "~1.2.2" }
+stwo-cairo-common = { path = "../common", version = "~1.3.0" }
 rayon.workspace = true
 serde.workspace = true
 starknet-curve.workspace = true
 starknet-ff.workspace = true
 starknet-types-core.workspace = true
-stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.2.2" }
+stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.3.0" }
 stwo.workspace = true
 stwo-constraint-framework.workspace = true
 thiserror.workspace = true

--- a/stwo_cairo_prover/crates/cairo-serialize/Cargo.toml
+++ b/stwo_cairo_prover/crates/cairo-serialize/Cargo.toml
@@ -8,5 +8,5 @@ description = "Serialization utilities for Stwo Cairo proofs"
 
 [dependencies]
 starknet-ff.workspace = true
-stwo-cairo-serialize-derive = { path = "../cairo-serialize-derive", version = "~1.2.2" }
+stwo-cairo-serialize-derive = { path = "../cairo-serialize-derive", version = "~1.3.0" }
 stwo.workspace = true

--- a/stwo_cairo_prover/crates/common/Cargo.toml
+++ b/stwo_cairo_prover/crates/common/Cargo.toml
@@ -16,7 +16,7 @@ ruint.workspace = true
 serde.workspace = true
 starknet-ff.workspace = true
 starknet-types-core.workspace = true
-stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.2.2" }
+stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.3.0" }
 stwo.workspace = true
 stwo-constraint-framework.workspace = true
 serde_arrays.workspace = true

--- a/stwo_cairo_prover/crates/dev_utils/Cargo.toml
+++ b/stwo_cairo_prover/crates/dev_utils/Cargo.toml
@@ -12,15 +12,15 @@ required-features = ["stwo-cairo-adapter/extract-mem-trace"]
 
 [dependencies]
 anyhow.workspace = true
-cairo-air = { path = "../cairo-air", version = "~1.2.2" }
+cairo-air = { path = "../cairo-air", version = "~1.3.0" }
 clap.workspace = true
 serde.workspace = true
 starknet-ff.workspace = true
 sonic-rs.workspace = true
-stwo-cairo-adapter = { path = "../adapter", version = "~1.2.2" }
-stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.2.2" }
+stwo-cairo-adapter = { path = "../adapter", version = "~1.3.0" }
+stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.3.0" }
 stwo.workspace = true
-stwo-cairo-prover = { path = "../prover", version = "~1.2.2" }
+stwo-cairo-prover = { path = "../prover", version = "~1.3.0" }
 tracing-subscriber.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/stwo_cairo_prover/crates/prover/Cargo.toml
+++ b/stwo_cairo_prover/crates/prover/Cargo.toml
@@ -23,8 +23,8 @@ itertools.workspace = true
 num-traits.workspace = true
 paste.workspace = true
 # TODO(Ohad): Add parallel config.
-stwo-cairo-common = { path = "../common", version = "~1.2.2", features = ["prover"] }
-stwo-cairo-adapter = { path = "../adapter", version = "~1.2.2" }
+stwo-cairo-common = { path = "../common", version = "~1.3.0", features = ["prover"] }
+stwo-cairo-adapter = { path = "../adapter", version = "~1.3.0" }
 rayon.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -32,8 +32,8 @@ anyhow.workspace = true
 starknet-curve.workspace = true
 starknet-ff.workspace = true
 starknet-types-core.workspace = true
-stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.2.2" }
-cairo-air = { path = "../cairo-air", version = "~1.2.2" }
+stwo-cairo-serialize = { path = "../cairo-serialize", version = "~1.3.0" }
+cairo-air = { path = "../cairo-air", version = "~1.3.0" }
 stwo = { workspace = true, features = ["parallel", "prover"] }
 stwo-constraint-framework = { workspace = true, features = ["parallel", "prover"] }
 tracing.workspace = true


### PR DESCRIPTION
## Summary

Prepares the `stwo_cairo_prover/` workspace crates for crates.io publishing at version **1.3.0**.

- Based on the exact rev pinned by the proving-utils tag **`v0.14.3-rust-bump`** (`9b6be271`, "Build stwo-cairo-prover on Rust 1.94 nightly").
- Bumps the workspace version **1.2.2 → 1.3.0**.
- Switches the stwo dependencies from git revs to published version requirements: `stwo`, `stwo-constraint-framework`, `stwo-air-utils-derive`, `stwo-air-utils` → **`2.3.0`**.
- All path dependencies bumped to `~1.3.0`.

## Dependency

**Depends on stwo 2.3.0 being published first** — this workspace cannot be fully resolved or published until stwo 2.3.0 is on crates.io.

## Publish order

1. stwo-cairo-serialize-derive
2. stwo-cairo-serialize
3. stwo-cairo-common
4. cairo-air
5. stwo-cairo-adapter
6. stwo-cairo-prover
7. stwo-cairo-utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1811)
<!-- Reviewable:end -->

---

**Update:** stwo 2.3.0 is now published. Regenerated `Cargo.lock` so the stwo crates resolve from crates.io at 2.3.0 (no more git source). `cargo check --workspace` passes against the published crate.