### PR TITLE
chore(verifier): bump cairo_test/cairo_execute to 2.18.0

### DIFF
--- a/stwo_cairo_verifier/Scarb.toml
+++ b/stwo_cairo_verifier/Scarb.toml
@@ -11,6 +11,10 @@ members = [
     "crates/verifier_utils",
 ]
 
+[workspace.dependencies]
+cairo_execute = "2.18.0"
+cairo_test = "2.18.0"
+
 [workspace.tool.cairo-lint]
 collapsible_if_else = false
 double_parens = false

--- a/stwo_cairo_verifier/crates/bounded_int/Scarb.toml
+++ b/stwo_cairo_verifier/crates/bounded_int/Scarb.toml
@@ -14,4 +14,4 @@ cairo-lint.workspace = true
 [dependencies]
 
 [dev-dependencies]
-cairo_test = "2.12.2"
+cairo_test.workspace = true

--- a/stwo_cairo_verifier/crates/cairo_air/Scarb.toml
+++ b/stwo_cairo_verifier/crates/cairo_air/Scarb.toml
@@ -26,4 +26,4 @@ stwo_constraint_framework = { path = "../constraint_framework" }
 stwo_verifier_utils = { path = "../verifier_utils" }
 
 [dev-dependencies]
-cairo_test = "2.12.2"
+cairo_test.workspace = true

--- a/stwo_cairo_verifier/crates/cairo_verifier/Scarb.toml
+++ b/stwo_cairo_verifier/crates/cairo_verifier/Scarb.toml
@@ -19,7 +19,7 @@ poseidon_outputs_packing = ["stwo_cairo_air/poseidon_outputs_packing"]
 
 [dependencies]
 stwo_cairo_air = { path = "../cairo_air" }
-cairo_execute = "2.12.2"
+cairo_execute.workspace = true
 
 [dev-dependencies]
-cairo_test = "2.12.2"
+cairo_test.workspace = true

--- a/stwo_cairo_verifier/crates/cairo_verifier_mock/Scarb.toml
+++ b/stwo_cairo_verifier/crates/cairo_verifier_mock/Scarb.toml
@@ -19,7 +19,7 @@ poseidon_outputs_packing = ["stwo_cairo_air/poseidon_outputs_packing"]
 
 [dependencies]
 stwo_cairo_air = { path = "../cairo_air" }
-cairo_execute = "2.12.2"
+cairo_execute.workspace = true
 
 [dev-dependencies]
-cairo_test = "2.12.2"
+cairo_test.workspace = true

--- a/stwo_cairo_verifier/crates/circuit_air/Scarb.toml
+++ b/stwo_cairo_verifier/crates/circuit_air/Scarb.toml
@@ -24,4 +24,4 @@ stwo_constraint_framework = { path = "../constraint_framework" }
 stwo_verifier_utils = { path = "../verifier_utils" }
 
 [dev-dependencies]
-cairo_test = "2.12.2"
+cairo_test.workspace = true

--- a/stwo_cairo_verifier/crates/circuit_verifier/Scarb.toml
+++ b/stwo_cairo_verifier/crates/circuit_verifier/Scarb.toml
@@ -18,7 +18,7 @@ qm31_opcode = ["stwo_circuit_air/qm31_opcode"]
 [dependencies]
 stwo_circuit_air = { path = "../circuit_air" }
 stwo_verifier_core = { path = "../verifier_core" }
-cairo_execute = "2.12.2"
+cairo_execute.workspace = true
 
 [dev-dependencies]
-cairo_test = "2.12.2"
+cairo_test.workspace = true

--- a/stwo_cairo_verifier/crates/constraint_framework/Scarb.toml
+++ b/stwo_cairo_verifier/crates/constraint_framework/Scarb.toml
@@ -16,4 +16,4 @@ cairo-lint.workspace = true
 stwo_verifier_core = { path = "../verifier_core" }
 
 [dev-dependencies]
-cairo_test = "2.12.2"
+cairo_test.workspace = true

--- a/stwo_cairo_verifier/crates/verifier_core/Scarb.toml
+++ b/stwo_cairo_verifier/crates/verifier_core/Scarb.toml
@@ -23,4 +23,4 @@ bounded_int = { path = "../bounded_int" }
 stwo_verifier_utils = { path = "../verifier_utils" }
 
 [dev-dependencies]
-cairo_test = "2.12.2"
+cairo_test.workspace = true

--- a/stwo_cairo_verifier/crates/verifier_utils/Scarb.toml
+++ b/stwo_cairo_verifier/crates/verifier_utils/Scarb.toml
@@ -22,4 +22,4 @@ sort-module-level-items = true
 bounded_int = { path = "../bounded_int" }
 
 [dev-dependencies]
-cairo_test = "2.12.2"
+cairo_test.workspace = true


### PR DESCRIPTION
Bump `cairo_test` / `cairo_execute` from 2.12.2 to 2.18.0 (matching the Scarb 2.18.0 toolchain pinned in `.tool-versions`).

Centralize both versions in `[workspace.dependencies]` in the verifier workspace root and switch each crate to `cairo_test.workspace = true` / `cairo_execute.workspace = true`, so future bumps touch one line instead of every crate manifest.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1812)
<!-- Reviewable:end -->
