### PR TITLE
Add yuvalsw as code owner of the e2e proof fixtures

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 stwo_cairo_prover/crates/cairo-air/src/components/constraints_regression_test_values.rs @anatgstarkware @gilbens-starkware
+stwo_cairo_prover/test_data/test_prove_verify_ret_opcode/proof.json @yuvalsw
+stwo_cairo_prover/test_data/test_prove_verify_all_opcode_components/proof.json @yuvalsw


### PR DESCRIPTION
Adds `@yuvalsw` as a code owner for the two end-to-end proof fixtures that tests regenerate and assert against:

- `stwo_cairo_prover/test_data/test_prove_verify_ret_opcode/proof.json`
- `stwo_cairo_prover/test_data/test_prove_verify_all_opcode_components/proof.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1814)
<!-- Reviewable:end -->
