### PR TITLE
Add stwo-cairo-dev-utils to the crates.io publish list

### DIFF
--- a/stwo_cairo_prover/scripts/publish_workspace_crates.sh
+++ b/stwo_cairo_prover/scripts/publish_workspace_crates.sh
@@ -65,6 +65,7 @@ CRATES_TO_PUBLISH=(
   stwo-cairo-adapter
   stwo-cairo-prover
   stwo-cairo-utils
+  stwo-cairo-dev-utils
 )
 
 echo "Publish order:"


### PR DESCRIPTION
## Problem

`stwo-cairo-dev-utils` is the only workspace member absent from `CRATES_TO_PUBLISH` in `scripts/publish_workspace_crates.sh`, so it has never been uploaded to crates.io — even though its manifest is fully publish-ready.

This blocks downstream consumers: `stwo-circuits` uses `stwo-cairo-dev-utils` as a **dev-dependency** (test helpers in its Cairo verifier). With the crate missing from the registry, that dependency can only be satisfied via a git dep, which drags the entire `stwo` + `stwo-cairo` graph back in at the pinned rev and produces duplicate, incompatible copies of `stwo` in the build.

## Change

Append `stwo-cairo-dev-utils` to `CRATES_TO_PUBLISH`. It is placed last: it depends on `cairo-air`, `stwo-cairo-adapter`, `stwo-cairo-serialize`, and `stwo-cairo-prover` (all earlier in the list) and on no other workspace crate, so the topological publish order holds.

## Verification

`cargo publish -p stwo-cairo-dev-utils --dry-run` (including the verify build against crates.io deps) succeeds — the crate compiles standalone and packages cleanly, confirming the only thing missing was its entry in the publish list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1815)
<!-- Reviewable:end -->
