### PR TITLE
fix(cairo_air): validate output segment start and length

### DIFF
--- a/stwo_cairo_verifier/crates/cairo_air/src/lib.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/lib.cairo
@@ -266,13 +266,16 @@ pub fn verify_cairo(proof: CairoProof) {
 fn verify_claim(claim: @CairoClaim) {
     let PublicData {
         public_memory: PublicMemory {
-            program, public_segments, output: _output, safe_call_ids: _safe_call_ids,
+            program, public_segments, output, safe_call_ids: _safe_call_ids,
             }, initial_state: CasmState {
             pc: initial_pc, ap: initial_ap, fp: initial_fp,
             }, final_state: CasmState {
             pc: final_pc, ap: final_ap, fp: final_fp,
         },
     } = claim.public_data;
+
+    // get_entries assumes that the output builtin starts at the final ap.
+    assert!(*public_segments.output.start_ptr.value == (*final_ap).into());
 
     verify_builtins(
         claim.range_check_builtin,
@@ -285,6 +288,7 @@ fn verify_claim(claim: @CairoClaim) {
         claim.poseidon_builtin,
         claim.ec_op_builtin,
         public_segments,
+        output.len(),
     );
     verify_program(*program, public_segments);
 
@@ -301,6 +305,7 @@ fn verify_claim(claim: @CairoClaim) {
     assert!(initial_fp == initial_ap);
     assert!(final_pc == 5);
     assert!(initial_ap <= final_ap);
+    assert!(final_ap < pow2(29));
 
     // Sanity check: ensure that the maximum address in the address_to_id component fits within a
     // 29-bit address space (i.e., is less than 2**29).
@@ -359,6 +364,7 @@ fn verify_builtins(
     poseidon_builtin: @Option<crate::components::poseidon_builtin::Claim>,
     ec_op_builtin: @Option<crate::components::ec_op_builtin::Claim>,
     segment_ranges: @PublicSegmentRanges,
+    n_outputs: u32,
 ) {
     assert!(pedersen_builtin_narrow_windows.is_none());
 
@@ -381,8 +387,10 @@ fn verify_builtins(
     assert!(keccak_segment_range.start_ptr.value == keccak_segment_range.stop_ptr.value);
 
     // Output builtin.
-    assert!(output_segment_range.stop_ptr.value <= @pow2(31));
-    assert!(output_segment_range.start_ptr.value <= output_segment_range.stop_ptr.value);
+    assert!(output_segment_range.stop_ptr.value < @pow2(29));
+    assert!(
+        *output_segment_range.stop_ptr.value == *output_segment_range.start_ptr.value + n_outputs,
+    );
 
     // All other supported builtins.
     check_builtin(


### PR DESCRIPTION
Assert the output segment starts at the final ap (which get_entries relies on) and spans exactly n_outputs entries
(stop_ptr - start_ptr == n_outputs), replacing the weaker start_ptr <= stop_ptr check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1817)
<!-- Reviewable:end -->
