### PR TITLE
fix(cairo_air): validate output segment start and length

### DIFF
--- a/stwo_cairo_prover/crates/cairo-air/src/air.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/air.rs
@@ -503,7 +503,18 @@ impl PublicMemory {
         let [program, output] =
             [&self.program, &self.output].map(|section| section.clone().into_iter().enumerate());
         let program_iter = program.map(move |(i, (id, value))| (initial_pc + i as u32, id, value));
-        let output_iter = output.map(move |(i, (id, value))| (final_ap + i as u32, id, value));
+
+        let SegmentRange {
+            start_ptr: output_start_ptr,
+            stop_ptr: output_stop_ptr,
+        } = self.public_segments.output;
+
+        // The output segment's declared length (`output_stop_ptr` - `output_start_ptr`) must match
+        // the number of output values.
+        let output_len: u32 = self.output.len().try_into().unwrap();
+        assert!(output_stop_ptr.value == output_start_ptr.value + output_len);
+        let output_iter =
+            output.map(move |(i, (id, value))| (output_start_ptr.value + i as u32, id, value));
 
         let [safe_call_id0, safe_call_id1] = self.safe_call_ids;
         // The safe call area should be [initial_fp, 0] and initial_fp should be the same as

--- a/stwo_cairo_verifier/crates/cairo_air/src/lib.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/lib.cairo
@@ -266,16 +266,13 @@ pub fn verify_cairo(proof: CairoProof) {
 fn verify_claim(claim: @CairoClaim) {
     let PublicData {
         public_memory: PublicMemory {
-            program, public_segments, output, safe_call_ids: _safe_call_ids,
+            program, public_segments, output: _, safe_call_ids: _safe_call_ids,
             }, initial_state: CasmState {
             pc: initial_pc, ap: initial_ap, fp: initial_fp,
             }, final_state: CasmState {
             pc: final_pc, ap: final_ap, fp: final_fp,
         },
     } = claim.public_data;
-
-    // get_entries assumes that the output builtin starts at the final ap.
-    assert!(*public_segments.output.start_ptr.value == (*final_ap).into());
 
     verify_builtins(
         claim.range_check_builtin,
@@ -288,7 +285,6 @@ fn verify_claim(claim: @CairoClaim) {
         claim.poseidon_builtin,
         claim.ec_op_builtin,
         public_segments,
-        output.len(),
     );
     verify_program(*program, public_segments);
 
@@ -364,7 +360,6 @@ fn verify_builtins(
     poseidon_builtin: @Option<crate::components::poseidon_builtin::Claim>,
     ec_op_builtin: @Option<crate::components::ec_op_builtin::Claim>,
     segment_ranges: @PublicSegmentRanges,
-    n_outputs: u32,
 ) {
     assert!(pedersen_builtin_narrow_windows.is_none());
 
@@ -388,9 +383,6 @@ fn verify_builtins(
 
     // Output builtin.
     assert!(output_segment_range.stop_ptr.value < @pow2(29));
-    assert!(
-        *output_segment_range.stop_ptr.value == *output_segment_range.start_ptr.value + n_outputs,
-    );
 
     // All other supported builtins.
     check_builtin(
@@ -580,10 +572,19 @@ pub impl PublicMemoryImpl of PublicMemoryTrait {
     ) -> PublicMemoryEntries {
         let mut pub_memory_entries = PublicMemoryEntriesTrait::empty();
 
-        // The program is loaded to `initial_pc`.
+        // Add program memory section entries.
         pub_memory_entries.add_memory_section(self.program, initial_pc);
-        // Output was written to `final_ap`.
-        pub_memory_entries.add_memory_section(self.output, final_ap);
+
+        let SegmentRange {
+            start_ptr: output_start_ptr, stop_ptr: output_stop_ptr,
+        } = self.public_segments.output;
+
+        // The output segment's declared length (`output_stop_ptr` - `output_start_ptr`) must match
+        // the number of output values.
+        assert!(*output_stop_ptr.value == *output_start_ptr.value + self.output.len());
+
+        // Add the output memory section entries.
+        pub_memory_entries.add_memory_section(self.output, *output_start_ptr.value);
 
         // The safe call area should be [initial_fp, 0] and initial_fp should be the same as
         // initial_ap.

--- a/stwo_cairo_verifier/crates/cairo_air/src/test_utils.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/test_utils.cairo
@@ -1,5 +1,6 @@
 use stwo_constraint_framework::{CommonLookupElements, LookupElementsTrait};
 use stwo_verifier_core::fields::qm31::qm31_const;
+use crate::components::memory_id_to_big::LARGE_MEMORY_VALUE_ID_BASE;
 use super::{MemorySmallValue, PublicDataImpl, PublicMemory, PublicSegmentRanges, SegmentRange};
 
 #[generate_trait]
@@ -15,8 +16,10 @@ pub impl LookupElementsDummyImpl of LookupElementsDummyTrait {
 /// `output_len` elements, each being a tuple of (id, value).
 pub fn mock_public_memory_with_outputs(output_len: u32) -> PublicMemory {
     let mut output = array![];
+    let output_len_id = 1000;
+
     for i in 0..output_len {
-        output.append((i, [i; 8]));
+        output.append((LARGE_MEMORY_VALUE_ID_BASE + i, [i; 8]));
     }
 
     let empty_segment = SegmentRange {
@@ -27,7 +30,11 @@ pub fn mock_public_memory_with_outputs(output_len: u32) -> PublicMemory {
     PublicMemory {
         program: [].span(),
         public_segments: PublicSegmentRanges {
-            output: empty_segment,
+            // The output segment range needs to be consistent with output.len()
+            output: SegmentRange {
+                start_ptr: MemorySmallValue { id: 0, value: 0 },
+                stop_ptr: MemorySmallValue { id: output_len_id, value: output_len },
+            },
             pedersen: empty_segment,
             range_check_128: empty_segment,
             ecdsa: empty_segment,


### PR DESCRIPTION
Assert the output segment starts at the final ap (which get_entries relies on) and spans exactly n_outputs entries
(stop_ptr - start_ptr == n_outputs), replacing the weaker start_ptr <= stop_ptr check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1819)
<!-- Reviewable:end -->
