### PR TITLE
refactor(verifier): remove unused InteractionClaim from memory_id_to_big

### DIFF
--- a/stwo_cairo_verifier/crates/cairo_air/src/components/memory_id_to_big.cairo
+++ b/stwo_cairo_verifier/crates/cairo_air/src/components/memory_id_to_big.cairo
@@ -79,20 +79,6 @@ pub impl ClaimImpl of ClaimTrait<Claim> {
     }
 }
 
-#[derive(Drop, Serde)]
-pub struct InteractionClaim {
-    pub big_claimed_sums: Array<QM31>,
-    pub claimed_sum: QM31,
-}
-
-#[generate_trait]
-pub impl InteractionClaimImpl of InteractionClaimTrait {
-    fn mix_into(self: @InteractionClaim, ref channel: Channel) {
-        channel.mix_felts(self.big_claimed_sums.span());
-    }
-}
-
-
 #[derive(Drop)]
 pub struct BigComponent {
     pub log_n_rows: u32,


### PR DESCRIPTION
The InteractionClaim struct and its mix_into impl in the memory_id_to_big component were dead code with no remaining references.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1821)
<!-- Reviewable:end -->
