### PR TITLE
Forward the qm31_opcode feature to stwo_constraint_framework.

### DIFF
--- a/stwo_cairo_verifier/crates/cairo_air/Scarb.toml
+++ b/stwo_cairo_verifier/crates/cairo_air/Scarb.toml
@@ -8,7 +8,7 @@ casm = true
 
 [features]
 poseidon252_verifier = ["stwo_verifier_core/poseidon252_verifier"]
-qm31_opcode = ["stwo_verifier_core/qm31_opcode"]
+qm31_opcode = ["stwo_verifier_core/qm31_opcode", "stwo_constraint_framework/qm31_opcode"]
 blake_outputs_packing = ["stwo_verifier_core/blake_outputs_packing"]
 poseidon_outputs_packing = ["stwo_verifier_core/poseidon_outputs_packing"]
 

--- a/stwo_cairo_verifier/crates/circuit_air/Scarb.toml
+++ b/stwo_cairo_verifier/crates/circuit_air/Scarb.toml
@@ -8,7 +8,7 @@ casm = true
 
 [features]
 poseidon252_verifier = ["stwo_verifier_core/poseidon252_verifier"]
-qm31_opcode = ["stwo_verifier_core/qm31_opcode"]
+qm31_opcode = ["stwo_verifier_core/qm31_opcode", "stwo_constraint_framework/qm31_opcode"]
 
 
 [tool.fmt]

--- a/stwo_cairo_verifier/crates/constraint_framework/Scarb.toml
+++ b/stwo_cairo_verifier/crates/constraint_framework/Scarb.toml
@@ -6,6 +6,9 @@ edition = "2024_07"
 [lib]
 casm = true
 
+[features]
+qm31_opcode = ["stwo_verifier_core/qm31_opcode"]
+
 [tool.fmt]
 sort-module-level-items = true
 


### PR DESCRIPTION
scarb resolves features only along explicit dep/feature edges, so the
cfg(feature: "qm31_opcode") impl selection in stwo_constraint_framework was
never enabled in scarb builds and the verifiers always compiled the
non-opcode LookupElementsImpl. Declare the feature in the crate and forward
it from stwo_cairo_air and stwo_circuit_air.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1824)
<!-- Reviewable:end -->
