### PR TITLE
ci: resolve scarb and rust nightly versions from their pin files

### DIFF
--- a/.github/workflows/cairo-ci.yaml
+++ b/.github/workflows/cairo-ci.yaml
@@ -9,7 +9,6 @@ on:
       - checks_requested
 
 env:
-  NIGHTLY_VERSION: "nightly-2026-01-15"
   STABLE_VERSION: "1.94.0"
 
 jobs:
@@ -21,8 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: software-mansion/setup-scarb@v1
-        with:
-          scarb-version: "2.18.0"
       - run: scarb fmt --check
 
   scarb-lint:
@@ -33,8 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: software-mansion/setup-scarb@v1
-        with:
-          scarb-version: "2.18.0"
       - run: scarb lint --features=qm31_opcode --deny-warnings
 
   scarb-test:
@@ -135,8 +130,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: software-mansion/setup-scarb@v1
-        with:
-          scarb-version: "2.18.0"
       - run: scarb test --features=${{ matrix.feature }} --package ${{ matrix.package }}
       - if: matrix.package == 'stwo_cairo_verifier'
         run: scarb --profile proving execute --package stwo_cairo_verifier --features ${{ matrix.feature }} --print-resource-usage --output none --arguments-file ${{ matrix.proof_file }}
@@ -155,8 +148,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: software-mansion/setup-scarb@v1
-        with:
-          scarb-version: "2.15.0"
       - run: scarb test --features=${{ matrix.feature }} --package ${{ matrix.package }}
       - if: matrix.package == 'stwo_circuit_verifier' && matrix.feature == 'qm31_opcode'
         run: scarb --profile proving execute --package stwo_circuit_verifier --features ${{ matrix.feature }} --print-resource-usage --output none --arguments-file crates/circuit_air/test_data/proof.json
@@ -180,8 +171,6 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: software-mansion/setup-scarb@v1
-        with:
-          scarb-version: "2.18.0"
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest
       - name: Fetch cache
@@ -198,9 +187,11 @@ jobs:
         working-directory: ./stwo_cairo_prover
     steps:
       - uses: actions/checkout@v6
+      - id: rust-toolchain
+        run: echo "channel=$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.NIGHTLY_VERSION }}
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
           targets: x86_64-unknown-linux-gnu
           components: rust-src
       - uses: Swatinem/rust-cache@v2
@@ -214,9 +205,11 @@ jobs:
         working-directory: ./stwo_cairo_prover
     steps:
       - uses: actions/checkout@v6
+      - id: rust-toolchain
+        run: echo "channel=$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.NIGHTLY_VERSION }}
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Build cairo-air for wasm32
@@ -245,10 +238,12 @@ jobs:
         working-directory: ./stwo_cairo_prover
     steps:
       - uses: actions/checkout@v6
+      - id: rust-toolchain
+        run: echo "channel=$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@master
         with:
           components: rustfmt
-          toolchain: ${{ env.NIGHTLY_VERSION }}
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
       - uses: Swatinem/rust-cache@v2
       - run: scripts/rust_fmt.sh --check
 
@@ -259,10 +254,12 @@ jobs:
         working-directory: ./stwo_cairo_prover
     steps:
       - uses: actions/checkout@v6
+      - id: rust-toolchain
+        run: echo "channel=$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@master
         with:
           components: clippy
-          toolchain: ${{ env.NIGHTLY_VERSION }}
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
       - uses: Swatinem/rust-cache@v2
       - run: scripts/clippy.sh
 
@@ -273,9 +270,11 @@ jobs:
         working-directory: ./stwo_cairo_prover
     steps:
       - uses: actions/checkout@v6
+      - id: rust-toolchain
+        run: echo "channel=$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)" >> "$GITHUB_OUTPUT"
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.NIGHTLY_VERSION }}
+          toolchain: ${{ steps.rust-toolchain.outputs.channel }}
       - name: Check Cargo.lock is up-to-date
         run: cargo fetch --locked
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -17,12 +17,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y build-essential
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: nightly-2026-01-15
       - name: Install Scarb
         uses: software-mansion/setup-scarb@v1
-        with:
-          scarb-version: "2.18.0"
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo test --release --features="nightly"


### PR DESCRIPTION
setup-scarb reads the repo-root .tool-versions when scarb-version is
omitted, and the dtolnay/rust-toolchain jobs now extract the channel
from stwo_cairo_prover/rust-toolchain.toml, so each version is defined
in one place. This also moves scarb-test-circuit from 2.15.0 to the
.tool-versions version (2.18.0); its tests and the circuit-verifier
execute step pass under 2.18.0. STABLE_VERSION stays a workflow env
var: it is a CI-only compatibility gate with no pin file.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1825)
<!-- Reviewable:end -->
