### PR TITLE
Fix edition-2024 match-ergonomics breakage

### DIFF
--- a/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
+++ b/stwo_cairo_prover/crates/cairo-air/src/verifier.rs
@@ -100,7 +100,7 @@ fn check_relation_uses(relation_uses: &HashMap<&'static str, u64>) {
 
     let outstanding_relations = relation_uses
         .iter()
-        .filter(|(_, &uses)| uses >= PRIME.into())
+        .filter(|&(_, &uses)| uses >= PRIME.into())
         .collect::<Vec<_>>();
 
     if !outstanding_relations.is_empty() {

--- a/stwo_cairo_prover/crates/cairo-serialize-derive/src/lib.rs
+++ b/stwo_cairo_prover/crates/cairo-serialize-derive/src/lib.rs
@@ -13,7 +13,7 @@ pub fn derive_cairo_serialize(input: TokenStream) -> TokenStream {
     // Extract the fields of the struct.
     let fields = match input.data {
         Data::Struct(ref data_struct) => match &data_struct.fields {
-            Fields::Named(ref fields_named) => &fields_named.named,
+            Fields::Named(fields_named) => &fields_named.named,
             Fields::Unnamed(_) | Fields::Unit => {
                 return syn::Error::new_spanned(
                     struct_name,
@@ -64,7 +64,7 @@ pub fn derive_cairo_deserialize(input: TokenStream) -> TokenStream {
     // Extract the fields of the struct.
     let fields = match input.data {
         Data::Struct(ref data_struct) => match &data_struct.fields {
-            Fields::Named(ref fields_named) => &fields_named.named,
+            Fields::Named(fields_named) => &fields_named.named,
             Fields::Unnamed(_) | Fields::Unit => {
                 return syn::Error::new_spanned(
                     struct_name,


### PR DESCRIPTION
Edition 2024 disallows explicit `ref`/`&` binding modifiers within implicitly-borrowing patterns (match-ergonomics change).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1830)
<!-- Reviewable:end -->
