### PR TITLE
docs: reference toolchain files instead of pinning versions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,8 @@ All agent behavior is governed by this hierarchy. No exception, no override.
 
 | Layer | Technology | Notes |
 |-------|-----------|-------|
-| Prover language | Rust nightly-2025-06-23 | See `stwo_cairo_prover/rust-toolchain.toml` |
-| Cairo verifier language | Cairo (2024_07 edition) | Scarb 2.15.0, for recursive verification |
+| Prover language | Rust | See `stwo_cairo_prover/rust-toolchain.toml` |
+| Cairo verifier language | Cairo | See `.tool-versions` |
 | Field | Mersenne31 (M31) | CM31, QM31 extension tower. p = 2^31 - 1 |
 | Proof system | Circle STARKs (via [stwo](https://github.com/starkware-libs/stwo)) | FRI-based, circle group C(F_p) |
 | Cairo VM | cairo-vm 3.2.0 | Trace extraction from Cairo CPU execution |


### PR DESCRIPTION
## What

The Stack table in `CLAUDE.md` hardcoded toolchain versions that had already drifted from reality:

| Field | Doc said | Actual |
|-------|----------|--------|
| Rust toolchain | `nightly-2025-06-23` | `nightly-2026-01-15` (`stwo_cairo_prover/rust-toolchain.toml`) |
| Scarb | `2.15.0` | `2.18.0` (`.tool-versions`) |

This PR removes the pinned versions and points to the source-of-truth files instead, so the doc can't drift again.

The `2024_07` Cairo edition detail was dropped from the table because it's set per-crate in each `Scarb.toml` (and isn't even uniform — `bounded_int` is on `2023_10`), so it doesn't fit as a single value in the Stack table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1831)
<!-- Reviewable:end -->
