### PR TITLE
feat(circuit_air): take preprocessed root from proof instead of hardcoding

### DIFF
--- a/stwo_cairo_verifier/crates/circuit_air/src/lib.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/lib.cairo
@@ -3,9 +3,7 @@
 use circuit_air::CircuitAirNewImpl;
 use core::dict::{Felt252DictTrait, SquashedFelt252DictTrait};
 use core::num::traits::Zero;
-use privacy_consts::{
-    N_OUTPUTS, PREPROCESSED_COLUMN_LOG_SIZES, circuit_pcs_config, preprocessed_root,
-};
+use privacy_consts::{N_OUTPUTS, PREPROCESSED_COLUMN_LOG_SIZES, circuit_pcs_config};
 use stwo_constraint_framework::LookupElementsImpl;
 pub use stwo_constraint_framework::{RelationUse, RelationUsesDict, accumulate_relation_uses};
 use stwo_verifier_core::Hash;
@@ -55,18 +53,23 @@ pub struct CircuitProof {
     pub channel_salt: u32,
 }
 
-/// The output of a circuit verification: `blake2s(preprocessed_root || output_values)`
+/// The output of a circuit verification: `blake2s(preprocessed_root || output_values)`,
+/// where `preprocessed_root` is the proof's preprocessed-trace (tree 0) commitment.
 #[derive(Drop, Serde)]
 pub struct VerificationOutput {
     pub output_hash: Hash,
 }
 
-/// Returns the output of the verifier: `blake2s(preprocessed_root || output_values)`.
+/// Returns the output of the verifier: `blake2s(preprocessed_root || output_values)`, where
+/// `preprocessed_root` is the proof's preprocessed-trace (tree 0) commitment.
 #[cfg(not(feature: "poseidon252_verifier"))]
-pub fn get_verification_output(proof: @CircuitProof) -> VerificationOutput {
-    let [r0, r1, r2, r3, r4, r5, r6, r7] = preprocessed_root().hash.unbox();
+pub fn get_verification_output(
+    commitments: @Box<[Hash; 4]>, output_values: Span<QM31>,
+) -> VerificationOutput {
+    let [preprocessed_commitment, _, _, _] = commitments.unbox();
+    let [r0, r1, r2, r3, r4, r5, r6, r7] = preprocessed_commitment.hash.unbox();
     let mut words = array![r0, r1, r2, r3, r4, r5, r6, r7];
-    for value in proof.claim.public_data.output_values.span() {
+    for value in output_values {
         let [c0, c1, c2, c3] = (*value).to_fixed_array();
         words.append(c0.into());
         words.append(c1.into());
@@ -77,7 +80,9 @@ pub fn get_verification_output(proof: @CircuitProof) -> VerificationOutput {
 }
 
 #[cfg(feature: "poseidon252_verifier")]
-pub fn get_verification_output(_proof: @CircuitProof) -> VerificationOutput {
+pub fn get_verification_output(
+    _commitments: @Box<[Hash; 4]>, _output_values: Span<QM31>,
+) -> VerificationOutput {
     panic!("the privacy recursive circuit verifier only supports the blake2s hasher")
 }
 
@@ -93,9 +98,7 @@ pub fn verify_circuit(proof: CircuitProof) {
     assert!(claim.public_data.output_values.len() == N_OUTPUTS);
 
     // Pin the proof's PCS config to the circuit's hardcoded canonical config. This rejects any
-    // proof produced with weaker/mismatched FRI parameters, and guarantees that
-    // `log_blowup_factor` matches the blowup the hardcoded `preprocessed_root()` was committed
-    // at.
+    // proof produced with weaker/mismatched FRI parameters.
     let pcs_config = stark_proof.commitment_scheme_proof.config;
     assert!(pcs_config == circuit_pcs_config(), "unexpected proof pcs config");
 
@@ -135,8 +138,9 @@ pub fn verify_circuit(proof: CircuitProof) {
     let log_blowup_factor = pcs_config.fri_config.log_blowup_factor;
 
     // Preprocessed trace. The preprocessed column log sizes are the hardcoded ones rather than
-    // the values derived from `component_log_sizes`.
-    assert!(preprocessed_commitment == preprocessed_root());
+    // the values derived from `component_log_sizes`. The preprocessed-trace commitment itself is
+    // taken from the proof and exposed in the verification output; binding it to the expected
+    // circuit topology is the responsibility of whoever consumes that output.
     commitment_scheme
         .commit(
             preprocessed_commitment,

--- a/stwo_cairo_verifier/crates/circuit_air/src/privacy_consts.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/privacy_consts.cairo
@@ -3,25 +3,18 @@
 //! These must match the recursive-verification circuit topology produced by the rust
 //! prover (`stwo-circuits/crates/circuit_verifier/src/verify.rs::build_verification_circuit`
 //! on the privacy circuit, plus the preprocessed trace built for that circuit). They are
-//! baked in at build time so the executable's `main` takes only a proof — mirroring how
-//! `cairo_air::verify_cairo` hardcodes its preprocessed root.
+//! baked in at build time so the executable's `main` takes only a proof.
 //!
-// TODO(Gali): Change to MultiVerifier consts.
 
-use core::box::BoxImpl;
-use stwo_verifier_core::Hash;
 use stwo_verifier_core::fri::FriConfig;
 use stwo_verifier_core::pcs::PcsConfig;
-#[cfg(not(feature: "poseidon252_verifier"))]
-use stwo_verifier_core::vcs::blake2s_hasher::Blake2sHash;
 
 /// Expected PCS config of the multiverifier circuit's proof.
 ///
 /// Hardcoded so the verifier accepts only proofs produced with the circuit's canonical
 /// configuration. This pins every FRI security parameter (a weaker config — fewer queries,
 /// smaller blowup, or less proof-of-work — is rejected, independently of stwo's
-/// `security_bits >= SECURITY_BITS` floor) and ties `log_blowup_factor` to the blowup the
-/// hardcoded `preprocessed_root()` was committed at. Must match the rust prover's
+/// `security_bits >= SECURITY_BITS` floor). Must match the rust prover's
 /// multiverifier `PCS_CONFIG` (`get_pcs_config(21, 3)`).
 /// Note `pow_bits + log_blowup_factor * n_queries = 27 + 3 * 23 = 96 = SECURITY_BITS`.
 pub fn circuit_pcs_config() -> PcsConfig {
@@ -90,25 +83,3 @@ pub const PREPROCESSED_COLUMN_LOG_SIZES: [u32; 45] = [
     21, // qm31_ops_out_address
     21 // qm31_ops_mults
 ];
-
-/// Expected preprocessed-trace root (Merkle commitment, tree 0 of the proof's
-/// commitments) for the multiverifier circuit at lifting_log_size = max(preprocessed column log
-/// sizes) + log_blowup_factor, as 8 little-endian u32 words of the Blake2s digest. Matches the
-/// prover-side `MULTIVERIFIER_PREPROCESSED_ROOT` in
-/// `stwo-circuits/crates/circuit_multiverifier/src/verify_test.rs`.
-#[cfg(not(feature: "poseidon252_verifier"))]
-pub fn preprocessed_root() -> Hash {
-    Blake2sHash {
-        hash: BoxImpl::new(
-            [
-                782313078, 3006801796, 1628870233, 3508238254, 21018123, 2160767231, 1298399148,
-                2430969455,
-            ],
-        ),
-    }
-}
-
-#[cfg(feature: "poseidon252_verifier")]
-pub fn preprocessed_root() -> Hash {
-    panic!("the privacy recursive circuit verifier only supports the blake2s hasher")
-}

--- a/stwo_cairo_verifier/crates/circuit_verifier/src/lib.cairo
+++ b/stwo_cairo_verifier/crates/circuit_verifier/src/lib.cairo
@@ -1,8 +1,18 @@
 use stwo_circuit_air::{CircuitProof, VerificationOutput, get_verification_output, verify_circuit};
+use stwo_verifier_core::Hash;
 
 #[executable]
 fn main(proof: CircuitProof) -> VerificationOutput {
-    let verification_output = get_verification_output(@proof);
+    /// Extract the commitments and output values before they are consumed by 'verify_circuit'.
+    let commitments: @Box<[Hash; 4]> = proof
+        .stark_proof
+        .commitment_scheme_proof
+        .commitments
+        .try_into()
+        .unwrap();
+    let output_values = proof.claim.public_data.output_values.span();
+    /// Verify the circuit.
     verify_circuit(:proof);
-    verification_output
+    /// Get the verification output.
+    get_verification_output(commitments, output_values)
 }


### PR DESCRIPTION
## Summary

`verify_circuit` (privacy/multiverifier circuit verifier) no longer pins the proof's preprocessed-trace (tree 0) commitment against a hardcoded `preprocessed_root()`. Instead, the verification output hashes the proof's **own** preprocessed commitment, and binding that commitment to the expected circuit topology becomes the responsibility of whoever consumes the verification output.

## Changes

- Remove the hardcoded `preprocessed_root()` constant and the `assert!(preprocessed_commitment == preprocessed_root())` check.
- `get_verification_output` now reads the preprocessed commitment from `commitment_scheme_proof.commitments[0]` rather than the baked-in constant.
- Drop now-unused imports (`preprocessed_root`, `Hash`, `Blake2sHash`, `BoxImpl`) and the comment tying `log_blowup_factor` to the blowup the hardcoded root was committed at.

## Soundness note

This intentionally relaxes what the circuit verifier itself checks: it no longer proves the preprocessed trace matches a fixed circuit. The preprocessed root is now surfaced in `VerificationOutput` (`blake2s(preprocessed_root || output_values)`), so the caller must bind it to the expected topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1836)
<!-- Reviewable:end -->
