### PR TITLE
feat(circuit_air): retarget multiverifier verifier to the default PCS config

### DIFF
--- a/stwo_cairo_verifier/crates/circuit_air/src/circuit_air.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/circuit_air.cairo
@@ -134,13 +134,13 @@ pub impl CircuitAirImpl of Air<CircuitAir> {
             verify_bitwise_xor_7,
             verify_bitwise_xor_8,
             range_check_16,
-            eq,
-            triple_xor,
-            m_31_to_u_32,
             verify_bitwise_xor_9,
-            blake_g_gate,
+            triple_xor,
+            eq,
+            m_31_to_u_32,
             verify_bitwise_xor_12,
             qm31_ops,
+            blake_g_gate,
         } = self;
 
         verify_bitwise_xor_4
@@ -179,7 +179,7 @@ pub impl CircuitAirImpl of Air<CircuitAir> {
                 random_coeff,
                 [].span(),
             );
-        eq
+        verify_bitwise_xor_9
             .evaluate_constraints_at_point(
                 ref sum,
                 ref preprocessed_mask_values,
@@ -197,25 +197,16 @@ pub impl CircuitAirImpl of Air<CircuitAir> {
                 random_coeff,
                 [].span(),
             );
+        eq
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
         m_31_to_u_32
-            .evaluate_constraints_at_point(
-                ref sum,
-                ref preprocessed_mask_values,
-                ref trace_mask_values,
-                ref interaction_trace_mask_values,
-                random_coeff,
-                [].span(),
-            );
-        verify_bitwise_xor_9
-            .evaluate_constraints_at_point(
-                ref sum,
-                ref preprocessed_mask_values,
-                ref trace_mask_values,
-                ref interaction_trace_mask_values,
-                random_coeff,
-                [].span(),
-            );
-        blake_g_gate
             .evaluate_constraints_at_point(
                 ref sum,
                 ref preprocessed_mask_values,
@@ -234,6 +225,15 @@ pub impl CircuitAirImpl of Air<CircuitAir> {
                 [].span(),
             );
         qm31_ops
+            .evaluate_constraints_at_point(
+                ref sum,
+                ref preprocessed_mask_values,
+                ref trace_mask_values,
+                ref interaction_trace_mask_values,
+                random_coeff,
+                [].span(),
+            );
+        blake_g_gate
             .evaluate_constraints_at_point(
                 ref sum,
                 ref preprocessed_mask_values,

--- a/stwo_cairo_verifier/crates/circuit_air/src/circuit_hash.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/circuit_hash.cairo
@@ -58,17 +58,17 @@ mod tests {
     use stwo_verifier_core::vcs::blake2s_hasher::Blake2sHash;
     use super::{BLAKE2S_DIGEST_N_WORDS, compute_circuit_hash};
 
-    /// Known-answer test: `blake2s` over the canonical `log_blowup_factor` (3) and component log
+    /// Known-answer test: `blake2s` over the canonical `log_blowup_factor` (1) and component log
     /// sizes, and `preprocessed_root = [0, 1, .., 7]`, cross-checked against an independent
     /// `blake2s` reference. This pins the byte packing against `compute_circuit_hash_host` in the
     /// stwo-circuits repo.
     #[test]
     fn compute_circuit_hash_matches_reference() {
-        let log_blowup_factor = 3;
+        let log_blowup_factor = 1;
         let preprocessed_root = Blake2sHash { hash: BoxImpl::new([0, 1, 2, 3, 4, 5, 6, 7]) };
         let expected: [u32; BLAKE2S_DIGEST_N_WORDS] = [
-            0xa8810641, 0x52391285, 0x90b37fd2, 0x905b887a, 0x7db7dc81, 0xa7c3a731, 0xd0d46b34,
-            0x8fa6a471,
+            0x5b6cadf2, 0x78860d2c, 0xde9b6924, 0xf656020c, 0xc965e2b2, 0x0bb57f82, 0x9236ceb4,
+            0x388feeb7,
         ];
         assert!(
             compute_circuit_hash(log_blowup_factor, preprocessed_root).hash.unbox() == expected,

--- a/stwo_cairo_verifier/crates/circuit_air/src/multiverifier_consts.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/multiverifier_consts.cairo
@@ -10,13 +10,13 @@ use crate::per_component::PerComponent;
 /// configuration. This pins every FRI security parameter (a weaker config — fewer queries,
 /// smaller blowup, or less proof-of-work — is rejected, independently of stwo's
 /// `security_bits >= SECURITY_BITS` floor). Must match the rust prover's
-/// multiverifier `PCS_CONFIG` (`get_pcs_config(21, 3)`).
-/// Note `pow_bits + log_blowup_factor * n_queries = 27 + 3 * 23 = 96 = SECURITY_BITS`.
+/// multiverifier `PCS_CONFIG` (`get_pcs_config(23, 1)`).
+/// Note `pow_bits + log_blowup_factor * n_queries = 26 + 1 * 70 = 96 = SECURITY_BITS`.
 pub fn circuit_pcs_config() -> PcsConfig {
     PcsConfig {
-        pow_bits: 27,
+        pow_bits: 26,
         fri_config: FriConfig {
-            log_blowup_factor: 3, log_last_layer_degree_bound: 0, n_queries: 23, fold_step: 4,
+            log_blowup_factor: 1, log_last_layer_degree_bound: 0, n_queries: 70, fold_step: 4,
         },
     }
 }
@@ -34,13 +34,13 @@ pub const COMPONENT_LOG_SIZES: PerComponent<u32> = PerComponent {
     verify_bitwise_xor_7: 14,
     verify_bitwise_xor_8: 16,
     range_check_16: 16,
-    eq: 17,
-    triple_xor: 17,
-    m_31_to_u_32: 18,
     verify_bitwise_xor_9: 18,
-    blake_g_gate: 20,
+    triple_xor: 19,
+    eq: 20,
+    m_31_to_u_32: 20,
     verify_bitwise_xor_12: 20,
-    qm31_ops: 21,
+    qm31_ops: 23,
+    blake_g_gate: 23,
 };
 
 /// Per-column log sizes of the multiverifier circuit's preprocessed trace,
@@ -59,30 +59,19 @@ pub const PREPROCESSED_COLUMN_LOG_SIZES: [u32; 45] = [
     COMPONENT_LOG_SIZES.verify_bitwise_xor_8, // bitwise_xor_8_0
     COMPONENT_LOG_SIZES.verify_bitwise_xor_8, // bitwise_xor_8_1
     COMPONENT_LOG_SIZES.verify_bitwise_xor_8, // bitwise_xor_8_2
-    COMPONENT_LOG_SIZES.eq, // eq_in0_address
-    COMPONENT_LOG_SIZES.eq, // eq_in1_address
+    COMPONENT_LOG_SIZES.verify_bitwise_xor_9, // bitwise_xor_9_0
+    COMPONENT_LOG_SIZES.verify_bitwise_xor_9, // bitwise_xor_9_1
+    COMPONENT_LOG_SIZES.verify_bitwise_xor_9, // bitwise_xor_9_2
     COMPONENT_LOG_SIZES.triple_xor, // triple_xor_input_addr_0
     COMPONENT_LOG_SIZES.triple_xor, // triple_xor_input_addr_1
     COMPONENT_LOG_SIZES.triple_xor, // triple_xor_input_addr_2
     COMPONENT_LOG_SIZES.triple_xor, // triple_xor_output_addr
     COMPONENT_LOG_SIZES.triple_xor, // triple_xor_multiplicity
+    COMPONENT_LOG_SIZES.eq, // eq_in0_address
+    COMPONENT_LOG_SIZES.eq, // eq_in1_address
     COMPONENT_LOG_SIZES.m_31_to_u_32, // m31_to_u32_input_addr
     COMPONENT_LOG_SIZES.m_31_to_u_32, // m31_to_u32_output_addr
     COMPONENT_LOG_SIZES.m_31_to_u_32, // m31_to_u32_multiplicity
-    COMPONENT_LOG_SIZES.verify_bitwise_xor_9, // bitwise_xor_9_0
-    COMPONENT_LOG_SIZES.verify_bitwise_xor_9, // bitwise_xor_9_1
-    COMPONENT_LOG_SIZES.verify_bitwise_xor_9, // bitwise_xor_9_2
-    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_input_addr_a
-    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_input_addr_b
-    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_input_addr_c
-    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_input_addr_d
-    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_input_addr_f0
-    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_input_addr_f1
-    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_output_addr_a
-    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_output_addr_b
-    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_output_addr_c
-    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_output_addr_d
-    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_multiplicity
     COMPONENT_LOG_SIZES.verify_bitwise_xor_12, // bitwise_xor_10_0
     COMPONENT_LOG_SIZES.verify_bitwise_xor_12, // bitwise_xor_10_1
     COMPONENT_LOG_SIZES.verify_bitwise_xor_12, // bitwise_xor_10_2
@@ -93,7 +82,18 @@ pub const PREPROCESSED_COLUMN_LOG_SIZES: [u32; 45] = [
     COMPONENT_LOG_SIZES.qm31_ops, // qm31_ops_in0_address
     COMPONENT_LOG_SIZES.qm31_ops, // qm31_ops_in1_address
     COMPONENT_LOG_SIZES.qm31_ops, // qm31_ops_out_address
-    COMPONENT_LOG_SIZES.qm31_ops // qm31_ops_mults
+    COMPONENT_LOG_SIZES.qm31_ops, // qm31_ops_mults
+    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_input_addr_a
+    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_input_addr_b
+    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_input_addr_c
+    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_input_addr_d
+    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_input_addr_f0
+    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_input_addr_f1
+    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_output_addr_a
+    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_output_addr_b
+    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_output_addr_c
+    COMPONENT_LOG_SIZES.blake_g_gate, // blake_g_gate_output_addr_d
+    COMPONENT_LOG_SIZES.blake_g_gate // blake_g_gate_multiplicity
 ];
 
 #[cfg(test)]
@@ -117,13 +117,13 @@ mod tests {
             components::verify_bitwise_xor_7::LOG_SIZE, // verify_bitwise_xor_7
             components::verify_bitwise_xor_8::LOG_SIZE, // verify_bitwise_xor_8
             components::range_check_16::LOG_SIZE, // range_check_16
-            *preprocessed_column_log_sizes.at(EQ_IN0_ADDRESS_IDX), // eq
-            *preprocessed_column_log_sizes.at(TRIPLE_XOR_INPUT_ADDR_0_IDX), // triple_xor
-            *preprocessed_column_log_sizes.at(M_31_TO_U_32_INPUT_ADDR_IDX), // m_31_to_u_32
             components::verify_bitwise_xor_9::LOG_SIZE, // verify_bitwise_xor_9
-            *preprocessed_column_log_sizes.at(BLAKE_G_GATE_INPUT_ADDR_A_IDX), // blake_g_gate
+            *preprocessed_column_log_sizes.at(TRIPLE_XOR_INPUT_ADDR_0_IDX), // triple_xor
+            *preprocessed_column_log_sizes.at(EQ_IN0_ADDRESS_IDX), // eq
+            *preprocessed_column_log_sizes.at(M_31_TO_U_32_INPUT_ADDR_IDX), // m_31_to_u_32
             components::verify_bitwise_xor_12::LOG_SIZE, // verify_bitwise_xor_12
-            *preprocessed_column_log_sizes.at(OP_0_ADDR_IDX) // qm31_ops
+            *preprocessed_column_log_sizes.at(OP_0_ADDR_IDX), // qm31_ops
+            *preprocessed_column_log_sizes.at(BLAKE_G_GATE_INPUT_ADDR_A_IDX) // blake_g_gate
         ]
     }
 

--- a/stwo_cairo_verifier/crates/circuit_air/src/per_component.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/per_component.cairo
@@ -15,13 +15,13 @@ pub struct PerComponent<T> {
     pub verify_bitwise_xor_7: T,
     pub verify_bitwise_xor_8: T,
     pub range_check_16: T,
-    pub eq: T,
-    pub triple_xor: T,
-    pub m_31_to_u_32: T,
     pub verify_bitwise_xor_9: T,
-    pub blake_g_gate: T,
+    pub triple_xor: T,
+    pub eq: T,
+    pub m_31_to_u_32: T,
     pub verify_bitwise_xor_12: T,
     pub qm31_ops: T,
+    pub blake_g_gate: T,
 }
 
 #[generate_trait]
@@ -30,9 +30,8 @@ pub impl PerComponentImpl<T, +Copy<T>, +Drop<T>> of PerComponentTrait<T> {
     fn to_fixed_array(self: @PerComponent<T>) -> [T; N_COMPONENTS] {
         [
             *self.verify_bitwise_xor_4, *self.verify_bitwise_xor_7, *self.verify_bitwise_xor_8,
-            *self.range_check_16, *self.eq, *self.triple_xor, *self.m_31_to_u_32,
-            *self.verify_bitwise_xor_9, *self.blake_g_gate, *self.verify_bitwise_xor_12,
-            *self.qm31_ops,
+            *self.range_check_16, *self.verify_bitwise_xor_9, *self.triple_xor, *self.eq,
+            *self.m_31_to_u_32, *self.verify_bitwise_xor_12, *self.qm31_ops, *self.blake_g_gate,
         ]
     }
 }
@@ -43,13 +42,13 @@ pub const N_TRACE_COLUMNS_PER_COMPONENT: PerComponent<usize> = PerComponent {
     verify_bitwise_xor_7: verify_bitwise_xor_7::N_TRACE_COLUMNS,
     verify_bitwise_xor_8: verify_bitwise_xor_8::N_TRACE_COLUMNS,
     range_check_16: range_check_16::N_TRACE_COLUMNS,
-    eq: eq::N_TRACE_COLUMNS,
-    triple_xor: triple_xor::N_TRACE_COLUMNS,
-    m_31_to_u_32: m_31_to_u_32::N_TRACE_COLUMNS,
     verify_bitwise_xor_9: verify_bitwise_xor_9::N_TRACE_COLUMNS,
-    blake_g_gate: blake_g_gate::N_TRACE_COLUMNS,
+    triple_xor: triple_xor::N_TRACE_COLUMNS,
+    eq: eq::N_TRACE_COLUMNS,
+    m_31_to_u_32: m_31_to_u_32::N_TRACE_COLUMNS,
     verify_bitwise_xor_12: verify_bitwise_xor_12::N_TRACE_COLUMNS,
     qm31_ops: qm31_ops::N_TRACE_COLUMNS,
+    blake_g_gate: blake_g_gate::N_TRACE_COLUMNS,
 };
 
 /// Number of interaction columns per component.
@@ -58,11 +57,11 @@ pub const N_INTERACTION_COLUMNS_PER_COMPONENT: PerComponent<usize> = PerComponen
     verify_bitwise_xor_7: verify_bitwise_xor_7::N_INTERACTION_COLUMNS,
     verify_bitwise_xor_8: verify_bitwise_xor_8::N_INTERACTION_COLUMNS,
     range_check_16: range_check_16::N_INTERACTION_COLUMNS,
-    eq: eq::N_INTERACTION_COLUMNS,
-    triple_xor: triple_xor::N_INTERACTION_COLUMNS,
-    m_31_to_u_32: m_31_to_u_32::N_INTERACTION_COLUMNS,
     verify_bitwise_xor_9: verify_bitwise_xor_9::N_INTERACTION_COLUMNS,
-    blake_g_gate: blake_g_gate::N_INTERACTION_COLUMNS,
+    triple_xor: triple_xor::N_INTERACTION_COLUMNS,
+    eq: eq::N_INTERACTION_COLUMNS,
+    m_31_to_u_32: m_31_to_u_32::N_INTERACTION_COLUMNS,
     verify_bitwise_xor_12: verify_bitwise_xor_12::N_INTERACTION_COLUMNS,
     qm31_ops: qm31_ops::N_INTERACTION_COLUMNS,
+    blake_g_gate: blake_g_gate::N_INTERACTION_COLUMNS,
 };

--- a/stwo_cairo_verifier/crates/circuit_air/src/preprocessed_columns.cairo
+++ b/stwo_cairo_verifier/crates/circuit_air/src/preprocessed_columns.cairo
@@ -17,7 +17,7 @@ pub const NUM_PREPROCESSED_COLUMNS: u32 = 45;
 
 // Multiverifier circuit column order (size-sorted ascending, stable on insertion order).
 // These positions match the prover-side `multiverifier_preprocessed_column_log_sizes()` in
-// `stwo-circuits/crates/circuit_multiverifier/src/verify_test.rs`.
+// `stwo-circuits/crates/circuit_multiverifier/src/test_utils.rs`.
 
 // bitwise_xor_4_{0,1,2} (log_size=8)
 pub const BITWISE_XOR_4_0_IDX: PreprocessedColumnIdx = 0;
@@ -37,59 +37,59 @@ pub const BITWISE_XOR_8_0_IDX: PreprocessedColumnIdx = 7;
 pub const BITWISE_XOR_8_1_IDX: PreprocessedColumnIdx = 8;
 pub const BITWISE_XOR_8_2_IDX: PreprocessedColumnIdx = 9;
 
-// eq_in{0,1}_address (log_size=17)
-pub const EQ_IN0_ADDRESS_IDX: PreprocessedColumnIdx = 10;
-pub const EQ_IN1_ADDRESS_IDX: PreprocessedColumnIdx = 11;
-
-// triple_xor_* (log_size=17)
-pub const TRIPLE_XOR_INPUT_ADDR_0_IDX: PreprocessedColumnIdx = 12;
-pub const TRIPLE_XOR_INPUT_ADDR_1_IDX: PreprocessedColumnIdx = 13;
-pub const TRIPLE_XOR_INPUT_ADDR_2_IDX: PreprocessedColumnIdx = 14;
-pub const TRIPLE_XOR_OUTPUT_ADDR_IDX: PreprocessedColumnIdx = 15;
-pub const TRIPLE_XOR_MULTIPLICITY_IDX: PreprocessedColumnIdx = 16;
-
-// m31_to_u32 columns (log_size=18)
-pub const M_31_TO_U_32_INPUT_ADDR_IDX: PreprocessedColumnIdx = 17;
-pub const M_31_TO_U_32_OUTPUT_ADDR_IDX: PreprocessedColumnIdx = 18;
-pub const M_31_TO_U_32_MULTIPLICITY_IDX: PreprocessedColumnIdx = 19;
-
 // bitwise_xor_9_{0,1,2} (log_size=18)
-pub const BITWISE_XOR_9_0_IDX: PreprocessedColumnIdx = 20;
-pub const BITWISE_XOR_9_1_IDX: PreprocessedColumnIdx = 21;
-pub const BITWISE_XOR_9_2_IDX: PreprocessedColumnIdx = 22;
+pub const BITWISE_XOR_9_0_IDX: PreprocessedColumnIdx = 10;
+pub const BITWISE_XOR_9_1_IDX: PreprocessedColumnIdx = 11;
+pub const BITWISE_XOR_9_2_IDX: PreprocessedColumnIdx = 12;
 
-// blake_g_gate_* (log_size=20)
-pub const BLAKE_G_GATE_INPUT_ADDR_A_IDX: PreprocessedColumnIdx = 23;
-pub const BLAKE_G_GATE_INPUT_ADDR_B_IDX: PreprocessedColumnIdx = 24;
-pub const BLAKE_G_GATE_INPUT_ADDR_C_IDX: PreprocessedColumnIdx = 25;
-pub const BLAKE_G_GATE_INPUT_ADDR_D_IDX: PreprocessedColumnIdx = 26;
-pub const BLAKE_G_GATE_INPUT_ADDR_F_0_IDX: PreprocessedColumnIdx = 27;
-pub const BLAKE_G_GATE_INPUT_ADDR_F_1_IDX: PreprocessedColumnIdx = 28;
-pub const BLAKE_G_GATE_OUTPUT_ADDR_A_IDX: PreprocessedColumnIdx = 29;
-pub const BLAKE_G_GATE_OUTPUT_ADDR_B_IDX: PreprocessedColumnIdx = 30;
-pub const BLAKE_G_GATE_OUTPUT_ADDR_C_IDX: PreprocessedColumnIdx = 31;
-pub const BLAKE_G_GATE_OUTPUT_ADDR_D_IDX: PreprocessedColumnIdx = 32;
-pub const BLAKE_G_GATE_MULTIPLICITY_IDX: PreprocessedColumnIdx = 33;
+// triple_xor_* (log_size=19)
+pub const TRIPLE_XOR_INPUT_ADDR_0_IDX: PreprocessedColumnIdx = 13;
+pub const TRIPLE_XOR_INPUT_ADDR_1_IDX: PreprocessedColumnIdx = 14;
+pub const TRIPLE_XOR_INPUT_ADDR_2_IDX: PreprocessedColumnIdx = 15;
+pub const TRIPLE_XOR_OUTPUT_ADDR_IDX: PreprocessedColumnIdx = 16;
+pub const TRIPLE_XOR_MULTIPLICITY_IDX: PreprocessedColumnIdx = 17;
+
+// eq_in{0,1}_address (log_size=20)
+pub const EQ_IN0_ADDRESS_IDX: PreprocessedColumnIdx = 18;
+pub const EQ_IN1_ADDRESS_IDX: PreprocessedColumnIdx = 19;
+
+// m31_to_u32 columns (log_size=20)
+pub const M_31_TO_U_32_INPUT_ADDR_IDX: PreprocessedColumnIdx = 20;
+pub const M_31_TO_U_32_OUTPUT_ADDR_IDX: PreprocessedColumnIdx = 21;
+pub const M_31_TO_U_32_MULTIPLICITY_IDX: PreprocessedColumnIdx = 22;
 
 // bitwise_xor_10_{0,1,2} (log_size=20) — privacy circuit names them
 // `bitwise_xor_10_*` rather than `bitwise_xor_12_*`. Auto-generated component code
 // references the legacy name, so we alias `BITWISE_XOR_12_*_IDX` here.
-pub const BITWISE_XOR_12_0_IDX: PreprocessedColumnIdx = 34;
-pub const BITWISE_XOR_12_1_IDX: PreprocessedColumnIdx = 35;
-pub const BITWISE_XOR_12_2_IDX: PreprocessedColumnIdx = 36;
+pub const BITWISE_XOR_12_0_IDX: PreprocessedColumnIdx = 23;
+pub const BITWISE_XOR_12_1_IDX: PreprocessedColumnIdx = 24;
+pub const BITWISE_XOR_12_2_IDX: PreprocessedColumnIdx = 25;
 
-// qm31_ops_* (log_size=21). Auto-generated components reference these without
+// qm31_ops_* (log_size=23). Auto-generated components reference these without
 // the `qm31_ops_` prefix (e.g. `ADD_FLAG_IDX`); the prover-side column names use the prefix
 // (`qm31_ops_add_flag`, ..., `qm31_ops_in0_address`, `qm31_ops_in1_address`,
 // `qm31_ops_out_address`, `qm31_ops_mults`).
-pub const ADD_FLAG_IDX: PreprocessedColumnIdx = 37;
-pub const SUB_FLAG_IDX: PreprocessedColumnIdx = 38;
-pub const MUL_FLAG_IDX: PreprocessedColumnIdx = 39;
-pub const POINTWISE_MUL_FLAG_IDX: PreprocessedColumnIdx = 40;
-pub const OP_0_ADDR_IDX: PreprocessedColumnIdx = 41;
-pub const OP_1_ADDR_IDX: PreprocessedColumnIdx = 42;
-pub const DST_ADDR_IDX: PreprocessedColumnIdx = 43;
-pub const QM_31_OPS_MULTIPLICITY_IDX: PreprocessedColumnIdx = 44;
+pub const ADD_FLAG_IDX: PreprocessedColumnIdx = 26;
+pub const SUB_FLAG_IDX: PreprocessedColumnIdx = 27;
+pub const MUL_FLAG_IDX: PreprocessedColumnIdx = 28;
+pub const POINTWISE_MUL_FLAG_IDX: PreprocessedColumnIdx = 29;
+pub const OP_0_ADDR_IDX: PreprocessedColumnIdx = 30;
+pub const OP_1_ADDR_IDX: PreprocessedColumnIdx = 31;
+pub const DST_ADDR_IDX: PreprocessedColumnIdx = 32;
+pub const QM_31_OPS_MULTIPLICITY_IDX: PreprocessedColumnIdx = 33;
+
+// blake_g_gate_* (log_size=23)
+pub const BLAKE_G_GATE_INPUT_ADDR_A_IDX: PreprocessedColumnIdx = 34;
+pub const BLAKE_G_GATE_INPUT_ADDR_B_IDX: PreprocessedColumnIdx = 35;
+pub const BLAKE_G_GATE_INPUT_ADDR_C_IDX: PreprocessedColumnIdx = 36;
+pub const BLAKE_G_GATE_INPUT_ADDR_D_IDX: PreprocessedColumnIdx = 37;
+pub const BLAKE_G_GATE_INPUT_ADDR_F_0_IDX: PreprocessedColumnIdx = 38;
+pub const BLAKE_G_GATE_INPUT_ADDR_F_1_IDX: PreprocessedColumnIdx = 39;
+pub const BLAKE_G_GATE_OUTPUT_ADDR_A_IDX: PreprocessedColumnIdx = 40;
+pub const BLAKE_G_GATE_OUTPUT_ADDR_B_IDX: PreprocessedColumnIdx = 41;
+pub const BLAKE_G_GATE_OUTPUT_ADDR_C_IDX: PreprocessedColumnIdx = 42;
+pub const BLAKE_G_GATE_OUTPUT_ADDR_D_IDX: PreprocessedColumnIdx = 43;
+pub const BLAKE_G_GATE_MULTIPLICITY_IDX: PreprocessedColumnIdx = 44;
 
 // Make sure INVALID_COLUMN_IDX is not the ID of any column
 const INVALID_IDX_CHECK: () = if NUM_PREPROCESSED_COLUMNS >= INVALID_COLUMN_IDX {


### PR DESCRIPTION
## What

The stwo-circuits multiverifier moved to its **default PCS config** (`get_pcs_config(23, 1)`: `pow_bits=26`, `log_blowup_factor=1`, `n_queries=70`) and regenerated its `cairo1_proof.json`. The Cairo1 circuit verifier still hardcoded the old config (`get_pcs_config(21, 3)`: `27/3/23`), so it rejected the new proof with `"unexpected proof pcs config"`.

Since the verifier commits/evaluates components in **size-sorted order** and the new config changes every component's trace log size, this required both new values *and* a new ordering. All edits are to hand-maintained (non AIR-generated) constant files in `circuit_air`.

## Changes

- `circuit_pcs_config()`: `27/3/23` → `26/1/70` (security stays `26 + 1·70 = 96`).
- `COMPONENT_LOG_SIZES` + `PREPROCESSED_COLUMN_LOG_SIZES`: new sizes and new size-sorted order.
- `preprocessed_columns.cairo`: renumber all 45 column indices.
- `PerComponent` field order + the component constraint-eval sequence in `circuit_air.cairo`: new committed order (`blake_g_gate` now last, after `qm31_ops`).
- `circuit_hash.cairo` KAT: recompute for `log_blowup_factor=1` and the new sizes.

New values/orderings were derived from stwo-circuits' authoritative sources (`multiverifier_preprocessed_column_log_sizes()`, `define_component_list!`, `sorted_component_order`), not guessed. The KAT recomputation was validated by first reproducing the old golden value.

## Verification

- `scarb execute -p stwo_circuit_verifier --arguments-file cairo1_proof.json` now succeeds under both `dev` and `proving` profiles.
- `scarb test -p stwo_circuit_air`: 3/3 pass (incl. `hardcoded_component_log_sizes_match_derived`, which cross-checks the three constant sets, and the recomputed KAT).
- `scarb fmt --check`, `scarb build`, `scarb lint --deny-warnings`: clean.

> ⚠️ Soundness-critical verifier config. Reviewers should confirm the new ordering against the stwo-circuits multiverifier config; ideally pair with a full-stack regression there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/stwo-cairo/1853)
<!-- Reviewable:end -->
